### PR TITLE
Revert "Use separate data for turku"

### DIFF
--- a/build-routers.sh
+++ b/build-routers.sh
@@ -98,8 +98,6 @@ function retrieveTurku() {
   curl -sS "http://dev.hsl.fi/gtfs.foli/foli.zip" -o foli.zip
 
   add_feed_id foli.zip FOLI
-
-  cp foli.zip $ROUTER_FINLAND/
 }
 
 

--- a/router-finland/gtfs-rules/matka.rule
+++ b/router-finland/gtfs-rules/matka.rule
@@ -22,8 +22,6 @@
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"2"}}
 # Tampere
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"3"}}
-# Tampere
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"14"}}
 # Oulu
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"220890"}}
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"220891"}}


### PR DESCRIPTION
This reverts commit 52c9c1ce813d5d1376aa63ca76d1b23da2af76dc.

Turku GTFS data is not valid for the current dates for now.