### PR TITLE
Remove route types 6 and 715 from matka.fi GTFS

### DIFF
--- a/router-finland/gtfs-rules/matka.rule
+++ b/router-finland/gtfs-rules/matka.rule
@@ -40,3 +40,7 @@
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"220973"}}
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"220968"}}
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"220968"}}
+
+# Waltti demand responsive transport
+{"op":"remove", "match":{"file":"routes.txt", "route_type":"6"}}
+{"op":"remove", "match":{"file":"routes.txt", "route_type":"715"}}


### PR DESCRIPTION
Route types 6 and 715 are used for demand responsive transport on Waltti