### PR TITLE
Longer timeouts for matka.fi

### DIFF
--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -1,5 +1,5 @@
 {
-  "timeouts": [8, 5, 2],
+  "timeouts": [20, 20, 20],
   "routingDefaults": {
     "walkSpeed": 1.3,
     "transferSlack": 120,


### PR DESCRIPTION
For some reason `[20, 20, 20] `works better than `20`