### PR TITLE
Use HSL vertexConnector in hsl build-config

### DIFF
--- a/router-hsl/build-config.json
+++ b/router-hsl/build-config.json
@@ -5,5 +5,6 @@
   "subwayAccessTime": 0,
   "osmWayPropertySet": "finland",
   "fares": "HSL",
-  "elevationUnitMultiplier": 0.1
+  "elevationUnitMultiplier": 0.1,
+  "vertexConnector": "HSL"
 }


### PR DESCRIPTION
* This allows OSM data to have H-prefix in hsl stops before gtfs data has it or vice versa