### PR TITLE
Use updated hsl dem data without NoData metatag

### DIFF
--- a/config.js
+++ b/config.js
@@ -132,7 +132,7 @@ const osm = [
 
 const dem = [
   { id: 'waltti', url: 'https://elevdata.blob.core.windows.net/elevation/waltti/waltti-10m-elevation-model.tif' },
-  { id: 'hsl', url: 'https://elevdata.blob.core.windows.net/elevation/hsl/hsl-10m-elevation-model_20190606.tif' }
+  { id: 'hsl', url: 'https://elevdata.blob.core.windows.net/elevation/hsl/hsl-10m-elevation-model_20190920.tif' }
 ]
 
 const constants = {


### PR DESCRIPTION
Workaround for https://github.com/opentripplanner/OpenTripPlanner/issues/2792 by removing NoData metatag usage from dem data