### PR TITLE
mapfit: skip fit if its not configured before checking for finland.pbf

### DIFF
--- a/task/MapFit.js
+++ b/task/MapFit.js
@@ -71,37 +71,39 @@ module.exports = {
       }
       const osmFile = `${dataDir}/ready/osm/finland.pbf`
 
+      if (config.fit === false) {
+        process.stdout.write(gtfsFile + ' fit skipped\n')
+        callback(null, file)
+        return
+      }
+
       if (!fs.existsSync(osmFile)) {
         process.stdout.write(`${osmFile} not available, skipping ${gtfsFile}\n`)
         callback(null, null)
         return
       }
-      if (config.fit === false) {
-        process.stdout.write(gtfsFile + ' fit skipped\n')
-        callback(null, file)
-      } else {
-        let script = ''
-        if (config.fit === true) {
-          script = 'gtfs_shape_mapfit/fit_gtfs.bash'
-        } else {
-          script = config.fit
-        }
-        const src = `${relativeFilename}`
-        const dst = `${relativeFilename}-fitted`
 
-        run(script, '/data/ready/osm/finland.pbf', src, dst).then((status) => {
-          if (status === true) {
-            fs.unlinkSync(src)
-            fs.renameSync(dst, src)
-            process.stdout.write(gtfsFile + ' fit SUCCESS\n')
-            file.contents = cloneable(fs.createReadStream(gtfsFile))
-            callback(null, file)
-          } else {
-            process.stdout.write(gtfsFile + ' fit FAILED\n')
-            callback(null, null)
-          }
-        })
+      let script = ''
+      if (config.fit === true) {
+        script = 'gtfs_shape_mapfit/fit_gtfs.bash'
+      } else {
+        script = config.fit
       }
+      const src = `${relativeFilename}`
+      const dst = `${relativeFilename}-fitted`
+
+      run(script, '/data/ready/osm/finland.pbf', src, dst).then((status) => {
+        if (status === true) {
+          fs.unlinkSync(src)
+          fs.renameSync(dst, src)
+          process.stdout.write(gtfsFile + ' fit SUCCESS\n')
+          file.contents = cloneable(fs.createReadStream(gtfsFile))
+          callback(null, file)
+        } else {
+          process.stdout.write(gtfsFile + ' fit FAILED\n')
+          callback(null, null)
+        }
+      })
     })
   }
 }


### PR DESCRIPTION
When trying to build an otp-data-con that is not based on finnish osm data, mapfit always fails, even if its not used (by setting mapfit to false in the src config for this router).

This PR simply moves the check if mapfit is going to be used before the check if finland.pbf exists.

(This is a part of the changes to make otp-data-container work easier for non hsl digitransits, see #189 )