### PR TITLE
Busybox timeout stopped working due to -t 

### DIFF
--- a/run-builder.sh
+++ b/run-builder.sh
@@ -59,7 +59,7 @@ while true; do
     echo "** Launching OTP data builder"
 
     #note: busybox timeout
-    timeout -t $MAX_TIME node index.js once
+    timeout $MAX_TIME node index.js once
     SUCCESS=$?
 
     if [ $SUCCESS = 143 ]; then
@@ -75,7 +75,7 @@ while true; do
     if [ $SUCCESS -ne 0 ]; then
         # try once more
         echo "** Restarting builder once"
-        timeout -t $MAX_TIME  node index.js once
+        timeout $MAX_TIME  node index.js once
         SUCCESS=$?
 
         if [ $SUCCESS = 143 ]; then


### PR DESCRIPTION
* Removing -t flag as it seems like it is not supported anymore and instead should be left out