### PR TITLE
Use non-cdn version of HSL zip URL

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,7 +10,7 @@ const src = (id, url, fit, rules) => ({ id, url, fit, rules })
 const HSL_CONFIG = {
   'id': 'hsl',
   'src': [
-    src('HSL', 'https://infopalvelut.storage.hsldev.com/gtfs/hsl.zip', false),
+    src('HSL', 'https://hslstorageinfopalvelut.blob.core.windows.net/gtfs/hsl.zip', false),
     src('HSLlautta', 'http://lautta.net/db/gtfs_pk/gtfs.zip', false)
   ],
   'osm': 'hsl',
@@ -20,7 +20,7 @@ const HSL_CONFIG = {
 const FINLAND_CONFIG = {
   'id': 'finland',
   'src': [
-    src('HSL', 'https://infopalvelut.storage.hsldev.com/gtfs/hsl.zip', false),
+    src('HSL', 'https://hslstorageinfopalvelut.blob.core.windows.net/gtfs/hsl.zip', false),
     src('MATKA', 'https://gtfsdatav2.blob.core.windows.net/gtfsdata-blob/matka.zip', 'gtfs_shape_mapfit/fit_gtfs_stops.bash', ['router-finland/gtfs-rules/matka.rule', 'router-finland/gtfs-rules/matka-id.rule']),
     src('tampere', 'http://www.tampere.fi/ekstrat/ptdata/tamperefeed_deprecated.zip', false),
     src('LINKKI', 'https://tvv.fra1.digitaloceanspaces.com/209.zip', 'gtfs_shape_mapfit/fit_gtfs_stops.bash'),


### PR DESCRIPTION
We noticed that the cdn version cached the zip even after it had been updated in the blob storage. So therefore we use this direct URL until the cache issue is fixed.