### PR TITLE
Remove shape_dist_traveled from matka data

### DIFF
--- a/router-finland/gtfs-rules/matka.rule
+++ b/router-finland/gtfs-rules/matka.rule
@@ -41,4 +41,5 @@
 # Waltti service points
 {"op":"remove", "match":{"file":"agency.txt", "agency_name":"R-Kioski"}}
 
-
+# Remove shape_dist_traveled from stop_times.txt as values in waltti GTFS are bogus
+{"op":"update", "match":{"file":"stop_times.txt", }, "update":{"shape_dist_traveled":-999.0}}


### PR DESCRIPTION
* OTP was ignoring shape entries because mismatch between shape_dist_traveled and shape distances