### PR TITLE
Add a new rule for removing tampere data from matka package

### DIFF
--- a/router-finland/gtfs-rules/matka.rule
+++ b/router-finland/gtfs-rules/matka.rule
@@ -20,8 +20,10 @@
 {"op":"remove", "match":{"file":"routes.txt", "agency_id":"4", "route_short_name":"Z"}}
 # HSL
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"2"}}
-# Tampere
+# Tampere old
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"3"}}
+# Tampere new
+{"op":"remove", "match":{"file":"agency.txt", "agency_name":"Nysse"}}
 # Oulu
 {"op":"remove", "match":{"file":"agency.txt", "agency_name":"Oulun joukkoliikenne"}}
 # Jyväskylä


### PR DESCRIPTION
* Tampere's data will be under a changing id in the future, so we remove it from the matka package by name now
  * old rule can remain because it will remain reserved for tampere