### PR TITLE
Finland data tuning

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@ const HSL_CONFIG = {
 const FINLAND_CONFIG = {
   'id': 'finland',
   'src': [
-    src('HSL', 'https://infopalvelut.storage.hsldev.com/gtfs/hsl.zip', false),
+    src('HSL', 'https://infopalvelut.storage.hsldev.com/gtfs/hsl.zip', false, ['router-finland/gtfs-rules/hsl.rule']),
     src('MATKA', 'https://gtfsdatav2.blob.core.windows.net/gtfsdata-blob/matka.zip', 'gtfs_shape_mapfit/fit_gtfs_stops.bash', ['router-finland/gtfs-rules/matka.rule', 'router-finland/gtfs-rules/matka-id.rule']),
     src('tampere', 'http://www.tampere.fi/ekstrat/ptdata/tamperefeed_deprecated.zip', false),
     src('LINKKI', 'https://tvv.fra1.digitaloceanspaces.com/209.zip', 'gtfs_shape_mapfit/fit_gtfs_stops.bash'),

--- a/router-finland/gtfs-rules/hsl.rule
+++ b/router-finland/gtfs-rules/hsl.rule
@@ -1,0 +1,4 @@
+# Removals from HSL gtfs package for matka.fi
+{"op":"remove", "match":{"file":"routes.txt", "agency_id":"HSL", "route_short_name":"R"}}
+{"op":"remove", "match":{"file":"routes.txt", "agency_id":"HSL", "route_short_name":"Z"}}
+

--- a/router-finland/gtfs-rules/matka.rule
+++ b/router-finland/gtfs-rules/matka.rule
@@ -18,8 +18,6 @@
 {"op":"remove", "match":{"file":"routes.txt", "agency_id":"4", "route_short_name":"Y"}}
 # HSL
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"2"}}
-{"op":"remove", "match":{"file":"routes.txt", "agency_id":"HSL", "route_short_name":"R"}}
-{"op":"remove", "match":{"file":"routes.txt", "agency_id":"HSL", "route_short_name":"Z"}}
 # Tampere old
 {"op":"remove", "match":{"file":"agency.txt", "agency_id":"3"}}
 # Tampere new

--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -129,6 +129,14 @@
       "url": "http://digitransit-proxy:8080/out/kaupunkipyorat.kuopio.fi/tkhs-export-map.html?format=xml",
       "frequencySec": 60,
       "network": "vilkku"
+    },
+    {
+      "id": "lappeenranta-bike-rental",
+      "type": "bike-rental",
+      "sourceType": "kaakau",
+      "url": "http://digitransit-proxy:8080/out/ckan.saita.fi/geojson/kaupunkipyoraparkit_lpr.geojson",
+      "frequencySec": 3600,
+      "network": "lappeenranta"
     }
   ],
   "boardTimes": {


### PR DESCRIPTION
- Proper filtering of R and Z trains from HSL data for finland routing
- Add lappeenranta citybikes into finland routing

