### PR TITLE
DT-4455 - remove some outdated OBA filtering rules

### DIFF
--- a/router-finland/gtfs-rules/matka.rule
+++ b/router-finland/gtfs-rules/matka.rule
@@ -20,22 +20,13 @@
 {"op":"remove", "match":{"file":"agency.txt", "agency_name":"Nysse"}}
 # Oulu
 {"op":"remove", "match":{"file":"agency.txt", "agency_name":"Oulun joukkoliikenne"}}
-# Jyväskylä
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220968"}}
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220969"}}
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220970"}}
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220971"}}
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220972"}}
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220973"}}
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220968"}}
-{"op":"remove", "match":{"file":"agency.txt", "agency_id":"220968"}}
 
-# Waltti demand responsive transport
+# Jyväskylä does not need filtering at the moment. Koontikanta does not include local Linkki traffic
+# and Waltti GTFS for Jyväskylä does not include long distance routes operated by Jyväskylän liikenne
+
+# Waltti demand responsive transport. BTW: why real on demand traffic is removed?
 {"op":"remove", "match":{"file":"routes.txt", "route_type":"6"}}
 {"op":"remove", "match":{"file":"routes.txt", "route_type":"715"}}
-
-# Waltti service points
-{"op":"remove", "match":{"file":"agency.txt", "agency_name":"R-Kioski"}}
 
 # Remove shape_dist_traveled from stop_times.txt as values in waltti GTFS are bogus
 {"op":"update", "match":{"file":"stop_times.txt", }, "update":{"shape_dist_traveled":-999.0}}

--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -92,6 +92,15 @@
       "fuzzyTripMatching": false
     },
     {
+      "id": "linkki-trip-updates",
+      "type": "stop-time-updater",
+      "frequencySec": 60,
+      "sourceType": "gtfs-http",
+      "url": "http://digitransit-proxy:8080/out/linkki.mattersoft.fi/api/gtfsrealtime/v1.0/feed/tripupdate",
+      "feedId": "LINKKI",
+      "fuzzyTripMatching": false
+    },
+    {
       "id": "linkki-alerts",
       "type": "real-time-alerts",
       "frequencySec": 30,

--- a/router-waltti/gtfs-rules/waltti.rule
+++ b/router-waltti/gtfs-rules/waltti.rule
@@ -1,6 +1,4 @@
-# Joensuu - remove route_type 6 = gondola
-{"op":"remove", "match":{"file":"routes.txt", "route_type":"6"}}
-# Joensuu, Kouvola and Lahti - map white route color to 'bus blue'
+# map white route color to 'bus blue'
 {"op":"update", "match":{"file":"routes.txt", "route_color":"FFFFFF"}, "update":{"route_color":""}}
 
 # Remove shape_dist_traveled from stop_times.txt as values in waltti GTFS are bogus


### PR DESCRIPTION
Some unused filters/updaters were kept, such as GTFS color transformation from white to bus color, in case the problem reappears in the future.