### PR TITLE
Add OTP2 configuration of unpreferred routes to HSL

### DIFF
--- a/router-hsl/router-config.json
+++ b/router-hsl/router-config.json
@@ -10,7 +10,23 @@
     "walkBoardCost": 540,
     "walkOnStreetReluctance": 1.5,
     "carParkCarLegWeight": 2,
-    "maxWheelchairSlope": 0.125
+    "maxWheelchairSlope": 0.125,
+    "itineraryFilters": {
+      "transitGeneralizedCostLimit": {
+        "costLimitFunction": "600 + 1.5x"
+      }
+    },
+    "unpreferredRouteCost": "600 + 3.0x",
+    "unpreferred": {
+      "routes": [
+        "HSL:2143A",
+        "HSL:2146A",
+        "HSL:2147A",
+        "HSL:2164A",
+        "HSL:2164VA",
+        "HSL:2321"
+      ]
+    }
   },
   "updaters": [
     {


### PR DESCRIPTION
 - Configuration of unpreferred routes, penalty function and cost limit function to HSL.
 - `transitGeneralizedCostLimit` filter function needs to be discussed in more detail, for now it suffices for testing 