### PR TITLE
Temporarily set high searchWindow in requests for testing

### DIFF
--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -1,5 +1,6 @@
 {
   "routingDefaults": {
+    "searchWindow": "12h",
     "walkSpeed": 1.3,
     "transferSlack": 120,
     "waitReluctance": 0.99,

--- a/router-hsl/router-config.json
+++ b/router-hsl/router-config.json
@@ -1,5 +1,6 @@
 {
   "routingDefaults": {
+    "searchWindow": "12h",
     "walkSpeed": 1.3,
     "transferSlack": 120,
     "waitReluctance": 0.95,

--- a/router-varely/router-config.json
+++ b/router-varely/router-config.json
@@ -1,5 +1,6 @@
 {
   "routingDefaults": {
+    "searchWindow": "12h",
     "walkSpeed": 1.3,
     "transferSlack": 120,
     "waitReluctance": 0.95,

--- a/router-waltti-alt/router-config.json
+++ b/router-waltti-alt/router-config.json
@@ -1,5 +1,6 @@
 {
   "routingDefaults": {
+    "searchWindow": "12h",
     "walkSpeed": 1.3,
     "transferSlack": 120,
     "waitReluctance": 0.95,

--- a/router-waltti/router-config.json
+++ b/router-waltti/router-config.json
@@ -1,5 +1,6 @@
 {
   "routingDefaults": {
+    "searchWindow": "12h",
     "walkSpeed": 1.3,
     "transferSlack": 120,
     "waitReluctance": 0.95,


### PR DESCRIPTION
This is done so we can "always" see a good set of itineraries for testing before paging is implemented in ui