### PR TITLE
DT-5730 longer transfer walks

### DIFF
--- a/router-finland/build-config.json
+++ b/router-finland/build-config.json
@@ -3,7 +3,7 @@
   "areaVisibility": true,
   "staticParkAndRide": false,
   "maxAreaNodes": 1000,
-  "maxTransferDurationSeconds": 1550,
+  "maxTransferDurationSeconds": 2700,
   "maxStopToShapeSnapDistance": 300,
   "transitServiceStart": "-P2W",
   "transitServiceEnd": "P12W",

--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -7,8 +7,8 @@
     "walkReluctance": 1.75,
     "carReluctance": 10.0,
     "stairsReluctance": 1.65,
-    "walkBoardCost": 60,
-    "bikeBoardCost": 60,
+    "walkBoardCost": 90,
+    "bikeBoardCost": 90,
     "maxAccessEgressDuration": "45m",
     "maxDirectStreetDuration": "100h",
     "maxDirectStreetDurationForMode": {

--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -7,8 +7,8 @@
     "walkReluctance": 1.75,
     "carReluctance": 10.0,
     "stairsReluctance": 1.65,
-    "walkBoardCost": 0,
-    "bikeBoardCost": 0,
+    "walkBoardCost": 60,
+    "bikeBoardCost": 60,
     "maxAccessEgressDuration": "45m",
     "maxDirectStreetDuration": "100h",
     "maxDirectStreetDurationForMode": {

--- a/router-waltti/build-config.json
+++ b/router-waltti/build-config.json
@@ -3,7 +3,7 @@
   "areaVisibility": true,
   "staticParkAndRide": false,
   "maxAreaNodes": 1000,
-  "maxTransferDurationSeconds": 1550,
+  "maxTransferDurationSeconds": 2700,
   "multiThreadElevationCalculations": true,
   "transitServiceStart": "-P2W",
   "transitServiceEnd": "P12W",

--- a/router-waltti/router-config.json
+++ b/router-waltti/router-config.json
@@ -7,8 +7,8 @@
     "walkReluctance": 1.75,
     "carReluctance": 10.0,
     "stairsReluctance": 1.65,
-    "walkBoardCost": 0,
-    "bikeBoardCost": 0,
+    "walkBoardCost": 60,
+    "bikeBoardCost": 60,
     "maxAccessEgressDuration": "45m",
     "maxDirectStreetDuration": "2h",
     "maxDirectStreetDurationForMode": {

--- a/router-waltti/router-config.json
+++ b/router-waltti/router-config.json
@@ -7,8 +7,8 @@
     "walkReluctance": 1.75,
     "carReluctance": 10.0,
     "stairsReluctance": 1.65,
-    "walkBoardCost": 60,
-    "bikeBoardCost": 60,
+    "walkBoardCost": 90,
+    "bikeBoardCost": 90,
     "maxAccessEgressDuration": "45m",
     "maxDirectStreetDuration": "2h",
     "maxDirectStreetDurationForMode": {


### PR DESCRIPTION
Add small default boarding cost and allow longer transfers in waltti and matka routing