### PR TITLE
DT-5841 increased the non transit cost limit to get more bike routes

### DIFF
--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -34,7 +34,7 @@
       "transitGeneralizedCostLimit": {
         "costLimitFunction": "600 + 1.5x"
       },
-      "nonTransitGeneralizedCostLimit": "180 + 1.2x"
+      "nonTransitGeneralizedCostLimit": "1800 + 2x"
     },
     "boardSlackForMode": {
       "AIRPLANE": "2700s"

--- a/router-hsl/router-config.json
+++ b/router-hsl/router-config.json
@@ -28,7 +28,7 @@
       "transitGeneralizedCostLimit": {
         "costLimitFunction": "600 + 1.5x"
       },
-      "nonTransitGeneralizedCostLimit": "180 + 1.2x"
+      "nonTransitGeneralizedCostLimit": "1800 + 2x"
     },
     "transitReluctanceForMode": {
       "BUS": 1.2,

--- a/router-waltti/router-config.json
+++ b/router-waltti/router-config.json
@@ -31,7 +31,7 @@
       "transitGeneralizedCostLimit": {
         "costLimitFunction": "600 + 1.5x"
       },
-      "nonTransitGeneralizedCostLimit": "180 + 1.2x"
+      "nonTransitGeneralizedCostLimit": "1800 + 2x"
     }
   },
   "transit": {


### PR DESCRIPTION
- nonTransitGeneralizedCostLimit increased significantly
-> bike routes are suggested more often
-> bike routes appear together with transit options and not just on their own

Related notes:
- Bike reluctance setting was not changed as increasing bike reluctance (above 3) causes routes that suggest walking past closer bike stops to get to a further one when the walking speed is fast. Decreasing too much causes inconvieniently long, winding bike routes.