### PR TITLE
Update configuration to work with otp v.2.4

### DIFF
--- a/router-finland/otp-config.json
+++ b/router-finland/otp-config.json
@@ -1,6 +1,6 @@
 {
   "otpFeatures": {
-      "SandboxAPILegacyGraphQLApi": true,
+      "GtfsGraphQlApi": true,
       "APIGraphInspectorTile": true,
       "APIServerInfo": true,
       "APIUpdaterStatus": false,

--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -12,6 +12,7 @@
     "bikeBoardCost": 120,
     "stairsTimeFactor": 2,
     "elevatorBoardTime": 60,
+    "maxAccessEgressStopCount": 300,
     "maxAccessEgressDuration": "1h",
     "maxDirectStreetDuration": "100h",
     "maxDirectStreetDurationForMode": {

--- a/router-finland/router-config.json
+++ b/router-finland/router-config.json
@@ -12,16 +12,18 @@
     "bikeBoardCost": 120,
     "stairsTimeFactor": 2,
     "elevatorBoardTime": 60,
-    "maxAccessEgressStopCount": 300,
-    "maxAccessEgressDuration": "1h",
+    "accessEgress": {
+      "maxStopCount": 500,
+      "maxDuration": "1h",
+      "maxDurationForMode": {
+        "CAR_TO_PARK": "2h"
+      }
+    },
     "maxDirectStreetDuration": "100h",
     "maxDirectStreetDurationForMode": {
       "walk": "90m"
     },
     "maxJourneyDuration": "24h",
-    "maxAccessEgressDurationForMode": {
-      "CAR_TO_PARK": "2h"
-    },
     "streetRoutingTimeout": "9s",
     "wheelchairAccessibility": {
       "stop": {

--- a/router-hsl/otp-config.json
+++ b/router-hsl/otp-config.json
@@ -1,6 +1,6 @@
 {
   "otpFeatures": {
-      "SandboxAPILegacyGraphQLApi": true,
+      "GtfsGraphQlApi": true,
       "APIGraphInspectorTile": true,
       "APIServerInfo": true,
       "APIUpdaterStatus": false,

--- a/router-hsl/router-config.json
+++ b/router-hsl/router-config.json
@@ -12,8 +12,10 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
-    "maxAccessEgressStopCount": 300,
-    "maxAccessEgressDuration": "35m",
+    "accessEgress": {
+      "maxStopCount": 500,
+      "maxDuration": "35m"
+    },
     "maxDirectStreetDuration": "90m",
     "maxJourneyDuration": "12h",
     "streetRoutingTimeout": "6s",

--- a/router-hsl/router-config.json
+++ b/router-hsl/router-config.json
@@ -12,6 +12,7 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
+    "maxAccessEgressStopCount": 300,
     "maxAccessEgressDuration": "35m",
     "maxDirectStreetDuration": "90m",
     "maxJourneyDuration": "12h",

--- a/router-kela/otp-config.json
+++ b/router-kela/otp-config.json
@@ -1,6 +1,6 @@
 {
   "otpFeatures": {
-      "SandboxAPILegacyGraphQLApi": true,
+      "GtfsGraphQlApi": true,
       "APIGraphInspectorTile": true,
       "APIServerInfo": true,
       "APIUpdaterStatus": false,

--- a/router-kela/router-config.json
+++ b/router-kela/router-config.json
@@ -12,6 +12,7 @@
     "bikeBoardCost": 120,
     "stairsTimeFactor": 2,
     "elevatorBoardTime": 60,
+    "maxAccessEgressStopCount": 300,
     "maxAccessEgressDuration": "8h",
     "maxDirectStreetDuration": "100h",
     "maxDirectStreetDurationForMode": {

--- a/router-kela/router-config.json
+++ b/router-kela/router-config.json
@@ -12,8 +12,10 @@
     "bikeBoardCost": 120,
     "stairsTimeFactor": 2,
     "elevatorBoardTime": 60,
-    "maxAccessEgressStopCount": 300,
-    "maxAccessEgressDuration": "8h",
+    "accessEgress": {
+      "maxStopCount": 500,
+      "maxDuration": "8h"
+    },
     "maxDirectStreetDuration": "100h",
     "maxDirectStreetDurationForMode": {
       "walk": "90m"

--- a/router-varely/otp-config.json
+++ b/router-varely/otp-config.json
@@ -1,6 +1,6 @@
 {
   "otpFeatures": {
-      "SandboxAPILegacyGraphQLApi": true,
+      "GtfsGraphQlApi": true,
       "APIGraphInspectorTile": true,
       "APIServerInfo": true,
       "APIUpdaterStatus": false,

--- a/router-varely/router-config.json
+++ b/router-varely/router-config.json
@@ -12,8 +12,10 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
-    "maxAccessEgressStopCount": 300,
-    "maxAccessEgressDuration": "45m",
+    "accessEgress": {
+      "maxStopCount": 500,
+      "maxDuration": "1h"
+    },
     "maxDirectStreetDuration": "2h",
     "maxDirectStreetDurationForMode": {
       "walk": "90m"

--- a/router-varely/router-config.json
+++ b/router-varely/router-config.json
@@ -12,6 +12,7 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
+    "maxAccessEgressStopCount": 300,
     "maxAccessEgressDuration": "45m",
     "maxDirectStreetDuration": "2h",
     "maxDirectStreetDurationForMode": {

--- a/router-waltti-alt/otp-config.json
+++ b/router-waltti-alt/otp-config.json
@@ -1,6 +1,6 @@
 {
   "otpFeatures": {
-      "SandboxAPILegacyGraphQLApi": true,
+      "GtfsGraphQlApi": true,
       "APIGraphInspectorTile": true,
       "APIServerInfo": true,
       "APIUpdaterStatus": false,

--- a/router-waltti-alt/router-config.json
+++ b/router-waltti-alt/router-config.json
@@ -12,6 +12,7 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
+    "maxAccessEgressStopCount": 300,
     "maxAccessEgressDuration": "45m",
     "maxDirectStreetDuration": "4h",
     "maxDirectStreetDurationForMode": {

--- a/router-waltti-alt/router-config.json
+++ b/router-waltti-alt/router-config.json
@@ -12,8 +12,10 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
-    "maxAccessEgressStopCount": 300,
-    "maxAccessEgressDuration": "45m",
+    "accessEgress": {
+      "maxStopCount": 500,
+      "maxDuration": "1h"
+    },
     "maxDirectStreetDuration": "4h",
     "maxDirectStreetDurationForMode": {
       "walk": "90m"

--- a/router-waltti/otp-config.json
+++ b/router-waltti/otp-config.json
@@ -1,6 +1,6 @@
 {
   "otpFeatures": {
-      "SandboxAPILegacyGraphQLApi": true,
+      "GtfsGraphQlApi": true,
       "APIGraphInspectorTile": true,
       "APIServerInfo": true,
       "APIUpdaterStatus": false,

--- a/router-waltti/router-config.json
+++ b/router-waltti/router-config.json
@@ -12,8 +12,10 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
-    "maxAccessEgressStopCount": 300,
-    "maxAccessEgressDuration": "45m",
+    "accessEgress": {
+      "maxStopCount": 500,
+      "maxDuration": "1h"
+    },
     "maxDirectStreetDuration": "2h",
     "maxDirectStreetDurationForMode": {
       "walk": "90m"

--- a/router-waltti/router-config.json
+++ b/router-waltti/router-config.json
@@ -12,6 +12,7 @@
     "elevatorBoardTime": 60,
     "walkBoardCost": 120,
     "bikeBoardCost": 120,
+    "maxAccessEgressStopCount": 300,
     "maxAccessEgressDuration": "45m",
     "maxDirectStreetDuration": "2h",
     "maxDirectStreetDurationForMode": {


### PR DESCRIPTION
- access/egress parameters have changed, they are now in a common sub group
-  Legacy graphql api switch name was updated (breaking change) 

NOTE: do not merge before https://github.com/opentripplanner/OpenTripPlanner/pull/5214 has been merged and digitransit  otp has been updated to new upstream state.

NOTE2: upstream OTP changes seem to slow down matka and kela routing  5 to 10 times!!! 
 