### PR TITLE
Mark processed rename rules correctly

### DIFF
--- a/task/GTFSReplace.js
+++ b/task/GTFSReplace.js
@@ -45,10 +45,10 @@ const replaceGTFSFiles = (fileContents, replacements, fileName, cb) => {
           resolve()
         }))
       } else if (replacementFile !== undefined) {
-        used[relativePath] = true
         // Replacement file defined, replace the file with the new one
         promises.push(zipWithNewName(zip, relativePath, replacementFile))
       }
+      used[relativePath] = true
     })
     // renamed replacements without existing counterpart
     Object.keys(replacements).forEach(name => {


### PR DESCRIPTION
{filename: null} GTFS rename rules were temporarily broken. Bug fixed.