### PR TITLE
Don't load in config before first slack message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build process for OpenTripPlanner-data-container
 
-[![Build](https://github.com/hsldevcom/OpenTripPlanner-data-container/workflows/Process%20master%20push%20or%20pr/badge.svg?branch=master)](https://github.com/HSLdevcom/OpenTripPlanner-data-container/actions)
+[![Build](https://github.com/hsldevcom/OpenTripPlanner-data-container/workflows/Process%20v3%20push%20or%20pr/badge.svg?branch=v3)](https://github.com/HSLdevcom/OpenTripPlanner-data-container/actions)
 
 ## This project:
 Contains tools for fetching, building and deploying fresh otp data-containers

--- a/config.js
+++ b/config.js
@@ -81,7 +81,7 @@ const routers = {
       mapSrc('Lahti', 'https://tvv.fra1.digitaloceanspaces.com/223.zip', true),
       mapSrc('Kuopio', 'http://karttapalvelu.kuopio.fi/google_transit/google_transit.zip'),
       mapSrc('OULU', 'https://tvv.fra1.digitaloceanspaces.com/229.zip'),
-      mapSrc('LINKKI', 'https://tvv.fra1.digitaloceanspaces.com/209.zip', true, undefined, {'fare_attributes.txt': 'digitransit_fare_attributes.txt', 'fare_rules.txt': 'digitransit_fare_rules.txt'}),
+      mapSrc('LINKKI', 'https://tvv.fra1.digitaloceanspaces.com/209.zip', true, undefined, { 'fare_attributes.txt': 'digitransit_fare_attributes.txt', 'fare_rules.txt': 'digitransit_fare_rules.txt' }),
       mapSrc('tampere', 'http://ekstrat.tampere.fi/ekstrat/ptdata/tamperefeed_deprecated.zip'),
       mapSrc('Rovaniemi', 'https://tvv.fra1.digitaloceanspaces.com/237.zip', true),
       mapSrc('digitraffic', 'https://rata.digitraffic.fi/api/v1/trains/gtfs-passenger-stops.zip', false, undefined, undefined, { headers: { 'Accept-Encoding': 'gzip', 'Digitraffic-User': 'Digitransit/OTP-dataloading' } }),

--- a/index.js
+++ b/index.js
@@ -10,5 +10,4 @@ postSlackMessage('Starting data build').then(response => {
   console.log(err)
   const { update } = require('./task/Update')
   update()
-});
-
+})

--- a/index.js
+++ b/index.js
@@ -1,108 +1,17 @@
-/*
-Executes gulp tasks which download new data, builds and tests a new graph and deploys a data container containing the results.
-Data errors are detected and tolerated to a certain limit thanks to fallback mechanism to older data.
-Unexpected code execution errors and failures in graph build abort the data loading.
-*/
-const gulp = require('gulp')
-require('./gulpfile')
-const { promisify } = require('util')
-const { execFileSync } = require('child_process')
-const { postSlackMessage, updateSlackMessage } = require('./util')
-const fs = require('fs')
-const { router } = require('./config')
+const { postSlackMessage } = require('./util')
 
-const MAX_GTFS_FALLBACK = 2 // threshold for aborting data loading
+startBuild()
 
-const start = promisify((task, cb) => gulp.series(task)(cb))
-
-update()
-
-async function update () {
-  const slackResponse = await postSlackMessage('Starting data build')
-  if (slackResponse.ok) {
-    global.messageTimeStamp = slackResponse.ts
-  }
-
-  if (!process.env.NOSEED) {
-    await start('seed')
-    process.stdout.write('Seeded\n')
-  }
-
-  // we track data rejections using this global variable
-  global.hasFailures = false
-  await start('dem:update')
-  if (global.hasFailures) {
-    postSlackMessage('DEM update failed, using previous version :boom:')
-  }
-
-  // OSM update is more complicated. Download often fails, so there is a retry loop,
-  //  which breaks when a big enough file gets loaded
-  global.blobSizeOk = false // ugly hack but gulp does not return any values from tasks
-  for (let i = 0; i < 3; i++) {
-    await start('osm:update')
-    if (global.blobSizeOk) {
-      break
+async function startBuild () {
+  postSlackMessage('Starting data build').then(response => {
+    if (response.ok) {
+      global.messageTimeStamp = response.ts
     }
-    if (i < 2) {
-      // sleep 10 mins before next attempt
-      await new Promise(resolve => setTimeout(resolve, 600000))
-    }
-  }
-  if (!global.blobSizeOk) {
-    global.hasFailures = true
-    postSlackMessage('OSM data update failed, using previous version :boom:')
-  }
-
-  const name = router.id
-  try {
-    await start('gtfs:update')
-
-    process.stdout.write('Build routing graph\n')
-    await start('router:buildGraph')
-
-    process.stdout.write('Build docker image\n')
-    execFileSync('./build.sh', [name], { stdio: [0, 1, 2] })
-
-    if (process.env.SKIPPED_SITES === 'all') {
-      process.stdout.write('Skipping all tests')
-    } else {
-      process.stdout.write('Test docker image\n')
-      execFileSync('./test.sh', [], { stdio: [0, 1, 2] })
-    }
-
-    const logFile = 'failed_feeds.txt'
-    if (fs.existsSync(logFile)) { // testing detected routing problems
-      global.hasFailures = true
-
-      global.failedFeeds = fs.readFileSync(logFile, 'utf8') // comma separated list of feed ids. No newline at end!
-      fs.unlinkSync(logFile) // cleanup for local use
-
-      if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
-        updateSlackMessage('Aborting the data update because too many quality tests failed :boom:')
-        process.exit(1)
-      }
-
-      postSlackMessage(`GTFS packages ${global.failedFeeds} rejected, using fallback to current data`)
-      // use seed packages for failed feeds
-      await start('gtfs:fallback')
-
-      // rebuild the graph
-      process.stdout.write('Rebuild graph using fallback data\n')
-      await start('router:buildGraph')
-
-      process.stdout.write('Rebuild docker image\n')
-      execFileSync('./build.sh', [name])
-    }
-    process.stdout.write('Deploy docker image\n')
-    execFileSync('./deploy.sh', [name], { stdio: [0, 1, 2] })
-
-    if (global.hasFailures) {
-      updateSlackMessage(`${name} data updated, but partially falling back to older data :boom:`)
-    } else {
-      updateSlackMessage(`${name} data updated :white_check_mark:`)
-    }
-  } catch (err) {
-    postSlackMessage(`${name} data update failed: ` + err.message)
-    updateSlackMessage('Something went wrong with the data update :boom:')
-  }
+    const { update } = require('./task/Update')
+    update()
+  }).catch((err) => {
+    console.log(err)
+    const { update } = require('./task/Update')
+    update()
+  })
 }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,14 @@
 const { postSlackMessage } = require('./util')
 
-startBuild()
+postSlackMessage('Starting data build').then(response => {
+  if (response.ok) {
+    global.messageTimeStamp = response.ts
+  }
+  const { update } = require('./task/Update')
+  update()
+}).catch((err) => {
+  console.log(err)
+  const { update } = require('./task/Update')
+  update()
+});
 
-async function startBuild () {
-  postSlackMessage('Starting data build').then(response => {
-    if (response.ok) {
-      global.messageTimeStamp = response.ts
-    }
-    const { update } = require('./task/Update')
-    update()
-  }).catch((err) => {
-    console.log(err)
-    const { update } = require('./task/Update')
-    update()
-  })
-}

--- a/task/Update.js
+++ b/task/Update.js
@@ -1,0 +1,105 @@
+/*
+Executes gulp tasks which download new data, builds and tests a new graph and deploys a data container containing the results.
+Data errors are detected and tolerated to a certain limit thanks to fallback mechanism to older data.
+Unexpected code execution errors and failures in graph build abort the data loading.
+*/
+const gulp = require('gulp')
+const { promisify } = require('util')
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const { postSlackMessage, updateSlackMessage } = require('../util')
+require('../gulpfile')
+const { router } = require('../config')
+
+const MAX_GTFS_FALLBACK = 2 // threshold for aborting data loading
+
+const start = promisify((task, cb) => gulp.series(task)(cb))
+
+async function update () {
+  if (!process.env.NOSEED) {
+    await start('seed')
+    process.stdout.write('Seeded\n')
+  }
+
+  // we track data rejections using this global variable
+  global.hasFailures = false
+  await start('dem:update')
+  if (global.hasFailures) {
+    postSlackMessage('DEM update failed, using previous version :boom:')
+  }
+
+  // OSM update is more complicated. Download often fails, so there is a retry loop,
+  //  which breaks when a big enough file gets loaded
+  global.blobSizeOk = false // ugly hack but gulp does not return any values from tasks
+  for (let i = 0; i < 3; i++) {
+    await start('osm:update')
+    if (global.blobSizeOk) {
+      break
+    }
+    if (i < 2) {
+      // sleep 10 mins before next attempt
+      await new Promise(resolve => setTimeout(resolve, 600000))
+    }
+  }
+  if (!global.blobSizeOk) {
+    global.hasFailures = true
+    postSlackMessage('OSM data update failed, using previous version :boom:')
+  }
+
+  const name = router.id
+  try {
+    await start('gtfs:update')
+
+    process.stdout.write('Build routing graph\n')
+    await start('router:buildGraph')
+
+    process.stdout.write('Build docker image\n')
+    execFileSync('./build.sh', [name], { stdio: [0, 1, 2] })
+
+    if (process.env.SKIPPED_SITES === 'all') {
+      process.stdout.write('Skipping all tests')
+    } else {
+      process.stdout.write('Test docker image\n')
+      execFileSync('./test.sh', [], { stdio: [0, 1, 2] })
+    }
+
+    const logFile = 'failed_feeds.txt'
+    if (fs.existsSync(logFile)) { // testing detected routing problems
+      global.hasFailures = true
+
+      global.failedFeeds = fs.readFileSync(logFile, 'utf8') // comma separated list of feed ids. No newline at end!
+      fs.unlinkSync(logFile) // cleanup for local use
+
+      if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
+        updateSlackMessage('Aborting the data update because too many quality tests failed :boom:')
+        process.exit(1)
+      }
+
+      postSlackMessage(`GTFS packages ${global.failedFeeds} rejected, using fallback to current data`)
+      // use seed packages for failed feeds
+      await start('gtfs:fallback')
+
+      // rebuild the graph
+      process.stdout.write('Rebuild graph using fallback data\n')
+      await start('router:buildGraph')
+
+      process.stdout.write('Rebuild docker image\n')
+      execFileSync('./build.sh', [name])
+    }
+    process.stdout.write('Deploy docker image\n')
+    execFileSync('./deploy.sh', [name], { stdio: [0, 1, 2] })
+
+    if (global.hasFailures) {
+      updateSlackMessage(`${name} data updated, but partially falling back to older data :boom:`)
+    } else {
+      updateSlackMessage(`${name} data updated :white_check_mark:`)
+    }
+  } catch (err) {
+    postSlackMessage(`${name} data update failed: ` + err.message)
+    updateSlackMessage('Something went wrong with the data update :boom:')
+  }
+}
+
+module.exports = {
+  update
+}


### PR DESCRIPTION
This fixes an issue where build crashes before the first slack message is sent.