### PR TITLE
DT-6324 filtering Kotka ferries by agency

### DIFF
--- a/waltti/gtfs-rules/only-kotka-ferries.rule
+++ b/waltti/gtfs-rules/only-kotka-ferries.rule
@@ -1,2 +1,2 @@
 # Only keep routes available in Kotka
-{"op":"retain", "match":{"file":"routes.txt", "route_id":"120590685"}}
+{"op":"retain", "match":{"file":"agency.txt", "agency_name":"Finferries"}}


### PR DESCRIPTION
- Kotka ferries now filtered by agency instead of route_id (unstable)