### PR TITLE
DT-6182 scooter max cache value lowered

### DIFF
--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -154,7 +154,7 @@
         "mapper": "Digitransit",
         "maxZoom": 20,
         "minZoom": 5,
-        "cacheMaxSeconds": 43200,
+        "cacheMaxSeconds": 45,
         "expansionFactor": 0.25
       },  
       {
@@ -163,7 +163,7 @@
         "mapper": "DigitransitRealtime",
         "maxZoom": 20,
         "minZoom": 5,
-        "cacheMaxSeconds": 43200,
+        "cacheMaxSeconds": 45,
         "expansionFactor": 0.25
       },
       {

--- a/hsl/router-config.json
+++ b/hsl/router-config.json
@@ -206,7 +206,7 @@
         "mapper": "Digitransit",
         "maxZoom": 20,
         "minZoom": 5,
-        "cacheMaxSeconds": 43200,
+        "cacheMaxSeconds": 45,
         "expansionFactor": 0.25
       },
       {
@@ -215,7 +215,7 @@
         "mapper": "DigitransitRealtime",
         "maxZoom": 20,
         "minZoom": 5,
-        "cacheMaxSeconds": 43200,
+        "cacheMaxSeconds": 45,
         "expansionFactor": 0.25
       },
       {


### PR DESCRIPTION
- Rental vehicle map cache max time was too long. Changed to match realtime cache value.