### PR TITLE
[Do not merge] DT-5921 Fix transfer cache requests

### DIFF
--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -63,26 +63,16 @@
         "walk": {
           "speed": 1.2,
           "reluctance": 1.8
-        }
-      },
-      {
-        "modes": "WALK",
-        "walk": {
-          "speed": 1.2,
-          "reluctance": 1.8
         },
         "wheelchairAccessibility": {
           "enabled": true
         }
       },
       {
-        "modes": "BICYCLE_RENT",
+        "modes": "WALK",
         "walk": {
           "speed": 1.2,
           "reluctance": 1.8
-        },
-        "bicycle": {
-          "speed": 5.55
         }
       },
       {
@@ -93,13 +83,38 @@
         }
       },
       {
-        "modes": "BICYCLE_RENT",
+        "modes": "BICYCLE",
+        "walk": {
+          "speed": 1.2,
+          "reluctance": 1.8
+        },
+        "bicycle": {
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          },
+          "optimization": "SAFEST_STREETS"
+        }
+      },
+      {
+        "modes": "BICYCLE",
         "walk": {
           "speed": 1.67,
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          },
+          "optimization": "SAFEST_STREETS"
+        }
+      },
+      {
+        "modes": "CAR",
+        "walk": {
+          "speed": 1.3,
+          "reluctance": 1.75
         }
       }
     ]

--- a/hsl/router-config.json
+++ b/hsl/router-config.json
@@ -95,36 +95,16 @@
         "walk": {
           "speed": 1.2,
           "reluctance": 1.8
-        }
-      },
-      {
-        "modes": "WALK",
-        "walk": {
-          "speed": 1.2,
-          "reluctance": 1.8
         },
         "wheelchairAccessibility": {
           "enabled": true
         }
       },
       {
-        "modes": "BICYCLE",
+        "modes": "WALK",
         "walk": {
           "speed": 1.2,
           "reluctance": 1.8
-        },
-        "bicycle": {
-          "speed": 5.55
-        }
-      },
-      {
-        "modes": "BICYCLE_RENT",
-        "walk": {
-          "speed": 1.2,
-          "reluctance": 1.8
-        },
-        "bicycle": {
-          "speed": 5.55
         }
       },
       {
@@ -137,21 +117,29 @@
       {
         "modes": "BICYCLE",
         "walk": {
-          "speed": 1.67,
+          "speed": 1.2,
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          },
+          "optimization": "SAFEST_STREETS"
         }
       },
       {
-        "modes": "BICYCLE_RENT",
+        "modes": "BICYCLE",
         "walk": {
           "speed": 1.67,
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          },
+          "optimization": "SAFEST_STREETS"
         }
       }
     ]

--- a/waltti/router-config.json
+++ b/waltti/router-config.json
@@ -61,26 +61,16 @@
         "walk": {
           "speed": 1.2,
           "reluctance": 1.8
-        }
-      },
-      {
-        "modes": "WALK",
-        "walk": {
-          "speed": 1.2,
-          "reluctance": 1.8
         },
         "wheelchairAccessibility": {
           "enabled": true
         }
       },
       {
-        "modes": "BICYCLE_RENT",
+        "modes": "WALK",
         "walk": {
           "speed": 1.2,
           "reluctance": 1.8
-        },
-        "bicycle": {
-          "speed": 5.55
         }
       },
       {
@@ -91,13 +81,38 @@
         }
       },
       {
-        "modes": "BICYCLE_RENT",
+        "modes": "BICYCLE",
+        "walk": {
+          "speed": 1.2,
+          "reluctance": 1.8
+        },
+        "bicycle": {
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          },
+          "optimization": "SAFEST_STREETS"
+        }
+      },
+      {
+        "modes": "BICYCLE",
         "walk": {
           "speed": 1.67,
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          },
+          "optimization": "SAFEST_STREETS"
+        }
+      },
+      {
+        "modes": "CAR",
+        "walk": {
+          "speed": 1.3,
+          "reluctance": 1.75
         }
       }
     ]


### PR DESCRIPTION
This PR removes the `BICYCLE_RENT` transfer cache requests that were not used. They are replaced with `BICYCLE` transfer cache requests that have additional fields. The added fields are non-required information in theory, but are required by the current OTP implementation.

This PR also adds `CAR` transfer cache requests in the finland and waltti configs. These will be properly utilized once the features from this PR are used: https://github.com/opentripplanner/OpenTripPlanner/pull/5966.