### PR TITLE
Updater liipi source type and enable debug raster tiles

### DIFF
--- a/finland/otp-config.json
+++ b/finland/otp-config.json
@@ -9,6 +9,7 @@
     "FloatingBike": true,
     "ActuatorAPI": true,
     "AsyncGraphQLFetchers": false,
-    "Co2Emissions": true
+    "Co2Emissions": true,
+    "DebugRasterTiles": true
   }
 }

--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -608,7 +608,7 @@
     {
       "id": "liipi",
       "type": "vehicle-parking",
-      "sourceType": "hsl-park",
+      "sourceType": "liipi",
       "feedId": "liipi",
       "timeZone": "Europe/Helsinki",
       "facilitiesFrequencySec": 3600,

--- a/hsl/otp-config.json
+++ b/hsl/otp-config.json
@@ -9,6 +9,7 @@
     "FloatingBike": true,
     "ActuatorAPI": true,
     "AsyncGraphQLFetchers": false,
-    "Co2Emissions": true
+    "Co2Emissions": true,
+    "DebugRasterTiles": true
   }
 }

--- a/hsl/router-config.json
+++ b/hsl/router-config.json
@@ -258,7 +258,7 @@
     {
       "id": "liipi",
       "type": "vehicle-parking",
-      "sourceType": "hsl-park",
+      "sourceType": "liipi",
       "feedId": "liipi",
       "timeZone": "Europe/Helsinki",
       "facilitiesFrequencySec": 3600,

--- a/kela/otp-config.json
+++ b/kela/otp-config.json
@@ -8,6 +8,7 @@
     "SandboxAPIMapboxVectorTilesApi": true,
     "FloatingBike": false,
     "ActuatorAPI": true,
-    "AsyncGraphQLFetchers": false
+    "AsyncGraphQLFetchers": false,
+    "DebugRasterTiles": true
   }
 }

--- a/varely/otp-config.json
+++ b/varely/otp-config.json
@@ -7,6 +7,7 @@
     "APIBikeRental": false,
     "SandboxAPIMapboxVectorTilesApi": true,
     "ActuatorAPI": true,
-    "AsyncGraphQLFetchers": false
+    "AsyncGraphQLFetchers": false,
+    "DebugRasterTiles": true
   }
 }

--- a/waltti-alt/otp-config.json
+++ b/waltti-alt/otp-config.json
@@ -7,6 +7,7 @@
     "APIBikeRental": false,
     "SandboxAPIMapboxVectorTilesApi": true,
     "ActuatorAPI": true,
-    "AsyncGraphQLFetchers": false
+    "AsyncGraphQLFetchers": false,
+    "DebugRasterTiles": true
   }
 }

--- a/waltti-alt/router-config.json
+++ b/waltti-alt/router-config.json
@@ -189,7 +189,7 @@
     {
       "id": "liipi",
       "type": "vehicle-parking",
-      "sourceType": "hsl-park",
+      "sourceType": "liipi",
       "feedId": "liipi",
       "timeZone": "Europe/Helsinki",
       "facilitiesFrequencySec": 3600,

--- a/waltti/otp-config.json
+++ b/waltti/otp-config.json
@@ -9,6 +9,7 @@
     "FloatingBike": false,
     "ActuatorAPI": true,
     "AsyncGraphQLFetchers": false,
-    "Co2Emissions": true
+    "Co2Emissions": true,
+    "DebugRasterTiles": true
   }
 }

--- a/waltti/router-config.json
+++ b/waltti/router-config.json
@@ -507,7 +507,7 @@
     {
       "id": "liipi",
       "type": "vehicle-parking",
-      "sourceType": "hsl-park",
+      "sourceType": "liipi",
       "feedId": "liipi",
       "timeZone": "Europe/Helsinki",
       "facilitiesFrequencySec": 3600,


### PR DESCRIPTION
* Liipi's source type changed in OTP code, that's why we need to update it
* Raster debug tiles were moved to a sandbox module as they are no longer used by the debug UIs, but we enable them since we use them in JOSM