### PR TITLE
Simplify `transferCacheRequests` in various configs

### DIFF
--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -5,11 +5,7 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7,
-      "optimization": "SAFEST_STREETS",
-      "rental": {
-        "useAvailabilityInformation": true
-      }
+      "reluctance": 1.7
     },
     "car": {
       "reluctance": 10.0,
@@ -101,7 +97,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       },
       {
@@ -111,7 +110,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       },
       {

--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -5,7 +5,8 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7
+      "reluctance": 1.7,
+      "optimization": "safest-streets"
     },
     "car": {
       "reluctance": 10.0,

--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -6,7 +6,10 @@
     "bicycle": {
       "boardCost": 120,
       "reluctance": 1.7,
-      "optimization": "safest-streets"
+      "optimization": "SAFEST_STREETS",
+      "rental": {
+        "useAvailabilityInformation": true
+      }
     },
     "car": {
       "reluctance": 10.0,
@@ -72,12 +75,6 @@
         "walk": {
           "speed": 1.2,
           "reluctance": 1.8
-        },
-        "accessEgress": {
-          "maxStopCountForMode": {
-            "BIKE": 0,
-            "CAR": 0
-          }
         }
       },
       {
@@ -88,12 +85,6 @@
         },
         "wheelchairAccessibility": {
           "enabled": true
-        },
-        "accessEgress": {
-          "maxStopCountForMode": {
-            "BIKE": 0,
-            "CAR": 0
-          }
         }
       },
       {
@@ -101,12 +92,6 @@
         "walk": {
           "speed": 1.67,
           "reluctance": 1.8
-        },
-        "accessEgress": {
-          "maxStopCountForMode": {
-            "BIKE": 0,
-            "CAR": 0
-          }
         }
       },
       {
@@ -116,17 +101,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
-        },
-        "accessEgress": {
-          "maxStopCountForMode": {
-            "BIKE": 0,
-            "CAR": 0
-          }
+          "speed": 5.55
         }
       },
       {
@@ -136,17 +111,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
-        },
-        "accessEgress": {
-          "maxStopCountForMode": {
-            "BIKE": 0,
-            "CAR": 0
-          }
+          "speed": 5.55
         }
       },
       {
@@ -154,12 +119,6 @@
         "walk": {
           "speed": 1.3,
           "reluctance": 1.75
-        },
-        "accessEgress": {
-          "maxStopCountForMode": {
-            "BIKE": 0,
-            "CAR": 0
-          }
         }
       }
     ]

--- a/hsl/router-config.json
+++ b/hsl/router-config.json
@@ -4,7 +4,8 @@
     "waitReluctance": 0.95,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7
+      "reluctance": 1.7,
+      "optimization": "safest-streets"
     },
     "car": {
       "reluctance": 10.0

--- a/hsl/router-config.json
+++ b/hsl/router-config.json
@@ -5,7 +5,10 @@
     "bicycle": {
       "boardCost": 120,
       "reluctance": 1.7,
-      "optimization": "safest-streets"
+      "optimization": "SAFEST_STREETS",
+      "rental": {
+        "useAvailabilityInformation": true
+      }
     },
     "car": {
       "reluctance": 10.0
@@ -125,11 +128,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       },
       {
@@ -139,11 +138,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       }
     ]

--- a/hsl/router-config.json
+++ b/hsl/router-config.json
@@ -4,11 +4,7 @@
     "waitReluctance": 0.95,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7,
-      "optimization": "SAFEST_STREETS",
-      "rental": {
-        "useAvailabilityInformation": true
-      }
+      "reluctance": 1.7
     },
     "car": {
       "reluctance": 10.0
@@ -128,7 +124,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       },
       {
@@ -138,7 +137,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       }
     ]

--- a/varely/router-config.json
+++ b/varely/router-config.json
@@ -5,11 +5,7 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7,
-      "optimization": "SAFEST_STREETS",
-      "rental": {
-        "useAvailabilityInformation": true
-      }
+      "reluctance": 1.7
     },
     "car": {
       "reluctance": 10.0
@@ -86,7 +82,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       },
       {
@@ -96,7 +95,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       }
     ]

--- a/varely/router-config.json
+++ b/varely/router-config.json
@@ -5,7 +5,8 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7
+      "reluctance": 1.7,
+      "optimization": "safest-streets"
     },
     "car": {
       "reluctance": 10.0

--- a/varely/router-config.json
+++ b/varely/router-config.json
@@ -6,7 +6,10 @@
     "bicycle": {
       "boardCost": 120,
       "reluctance": 1.7,
-      "optimization": "safest-streets"
+      "optimization": "SAFEST_STREETS",
+      "rental": {
+        "useAvailabilityInformation": true
+      }
     },
     "car": {
       "reluctance": 10.0
@@ -83,11 +86,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       },
       {
@@ -97,11 +96,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       }
     ]

--- a/waltti-alt/router-config.json
+++ b/waltti-alt/router-config.json
@@ -5,11 +5,7 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7,
-      "optimization": "SAFEST_STREETS",
-      "rental": {
-        "useAvailabilityInformation": true
-      }
+      "reluctance": 1.7
     },
     "car": {
       "reluctance": 10.0
@@ -86,7 +82,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       },
       {
@@ -96,7 +95,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       }
     ]

--- a/waltti-alt/router-config.json
+++ b/waltti-alt/router-config.json
@@ -5,7 +5,8 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7
+      "reluctance": 1.7,
+      "optimization": "safest-streets"
     },
     "car": {
       "reluctance": 10.0

--- a/waltti-alt/router-config.json
+++ b/waltti-alt/router-config.json
@@ -6,7 +6,10 @@
     "bicycle": {
       "boardCost": 120,
       "reluctance": 1.7,
-      "optimization": "safest-streets"
+      "optimization": "SAFEST_STREETS",
+      "rental": {
+        "useAvailabilityInformation": true
+      }
     },
     "car": {
       "reluctance": 10.0
@@ -83,11 +86,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       },
       {
@@ -97,11 +96,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       }
     ]

--- a/waltti/router-config.json
+++ b/waltti/router-config.json
@@ -5,11 +5,7 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7,
-      "optimization": "SAFEST_STREETS",
-      "rental": {
-        "useAvailabilityInformation": true
-      }
+      "reluctance": 1.7
     },
     "car": {
       "reluctance": 10.0
@@ -86,7 +82,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       },
       {
@@ -96,7 +95,10 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55
+          "speed": 5.55,
+          "rental": {
+            "useAvailabilityInformation": true
+          }
         }
       }
     ]

--- a/waltti/router-config.json
+++ b/waltti/router-config.json
@@ -5,7 +5,8 @@
     "elevatorBoardTime": 60,
     "bicycle": {
       "boardCost": 120,
-      "reluctance": 1.7
+      "reluctance": 1.7,
+      "optimization": "safest-streets"
     },
     "car": {
       "reluctance": 10.0

--- a/waltti/router-config.json
+++ b/waltti/router-config.json
@@ -6,7 +6,10 @@
     "bicycle": {
       "boardCost": 120,
       "reluctance": 1.7,
-      "optimization": "safest-streets"
+      "optimization": "SAFEST_STREETS",
+      "rental": {
+        "useAvailabilityInformation": true
+      }
     },
     "car": {
       "reluctance": 10.0
@@ -83,11 +86,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       },
       {
@@ -97,11 +96,7 @@
           "reluctance": 1.8
         },
         "bicycle": {
-          "speed": 5.55,
-          "rental": {
-            "useAvailabilityInformation": true
-          },
-          "optimization": "SAFEST_STREETS"
+          "speed": 5.55
         }
       }
     ]


### PR DESCRIPTION
This is partially dependent on https://github.com/opentripplanner/OpenTripPlanner/pull/6488, however I think this can still be merged because the fix will be merged to OTP at some point and the only broken thing will be the `transferCacheRequests` in the Finland config (the initial cache generation will not create usable cache entries and they will have to be regenerated on-demand).

Notes:
- I removed `"optimization": "safest-streets"` from the transfer cache requests
- The
```
"rental": {
  "useAvailabilityInformation": true
},
```
configuration is only in the transfer cache requests because it can be set by the API and should not be a default