### PR TITLE
DT-6763 Split graph build

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ It is possible to change the behaviour of the data builder by defining environme
 ### Data processing steps
 
 - `seed` downloads previous data from storage (env variable SEED_TAG can be used to customize which storage location is used)
-and then extracts osm, dem, and gtfs data and places it in the `data/seed` and `data/ready` directories.
-The old data acts as backup in case fetching/validating new data fails. The command uses the zipped contents of the latest build that built a complete graph (from prebuilt data or from a normal build).
+  and then extracts osm, dem, and gtfs data and places it in the `data/seed` and `data/ready` directories.
+  The old data acts as backup in case fetching/validating new data fails. The command uses the zipped contents of the latest build that built a complete graph (from prebuilt data or from a normal build).
 
 - `dem:update` downloads required DEM information, after which data is copied to the `data/downloads/dem` directory.
 
 - `osm:update` downloads required OSM packages from configured locations, tests the files with OTP,
-and if the tests pass, data is copied to the `data/downloads/osm` directory.
+  and if the tests pass, data is copied to the `data/downloads/osm` directory.
 
 - `gtfs:update`
 
   - `gtfs:dl` downloads a GTFS package from a configured location and tests the file with OTP, if
-  the test passes data is copied to the `data/fit/gtfs` directory. The resulting zip file is named `<feedid>.zip`.
+    the test passes data is copied to the `data/fit/gtfs` directory. The resulting zip file is named `<feedid>.zip`.
 
   - `gtfs:fit` runs configured map fits. Copies data to the `data/filter/gtfs` directory.
 
@@ -86,34 +86,37 @@ and if the tests pass, data is copied to the `data/downloads/osm` directory.
   - `gtfs:id` sets the gtfs feed id to `<id>` and copies data to the `data/ready/gtfs` directory.
 
 - `router:buildGraph`
+
   - `router:copy` copies files needed for the build.
   - `buildOTPGraphTask(config.router)` builds a new graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
 - `router:buildStreetOnlyGraph`
+
   - `router:copyStreetOnlyGraphData` copies files needed for the street only build.
   - `buildOTPStreetOnlyGraphTask(config.router)` builds a new street only graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
 - `router:buildWithPrebuiltStreetGraph`
+
   - `router:copyForPrebuiltStreetGraphDataBuild` copies files needed for the build from prebuilt data.
   - `buildOTPGraphTask(config.router)` builds a new graph from prebuilt street only data with new gtfs data sets (and maybe seeded data sets if there were issues with new data).
 
 - `test.sh` runs the routing quality test bench defined in the `hsldevcom/OTPQA` repository. OTPQA test sets are associated with GTFS packages.
-If there are quality regressions, a comma separated list of failed GTFS feed identifiers is written to the local file `failed_feeds.txt`.
+  If there are quality regressions, a comma separated list of failed GTFS feed identifiers is written to the local file `failed_feeds.txt`.
 
 - `router:store` stores the new data in storage (which can be a mounted storage volume).
 
 - `router:storeForPrebuiltStreetGraphDataBuild` stores the new data in storage (which can be a mounted storage volume). Also copies the `report` directory from the street only build to the output directory under the name `street-report`.
 
 - `deploy.sh` deploys a new opentripplanner-data-server image with the `DOCKER_TAG` env variable (default `v3`) postfixed with the router name, and
-pushes the image to Dockerhub.<p>
-Normally, when the application is running as a container, the script `index.js` is run to execute all steps.
-The end result of the build is a data server image uploaded to dockerhub.<p>
-Each data server image runs an http server listening to port `8080`, serving both a data bundle required for building a graph,
-and a pre-built graph. For example, in the HSL case: http://localhost:8080/router-hsl.zip and `graph-hsl-$OTPVERSION.zip`. The image
-does not include the data, the data needs to be mounted while running the container.
+  pushes the image to Dockerhub.<p>
+  Normally, when the application is running as a container, the script `index.js` is run to execute all steps.
+  The end result of the build is a data server image uploaded to dockerhub.<p>
+  Each data server image runs an http server listening to port `8080`, serving both a data bundle required for building a graph,
+  and a pre-built graph. For example, in the HSL case: http://localhost:8080/router-hsl.zip and `graph-hsl-$OTPVERSION.zip`. The image
+  does not include the data, the data needs to be mounted while running the container.
 
 - `deploy-otp.sh` tags an OTP image using the `OTP_TAG` env variable (default `v2`) postfixed with the router name and pushes the image to Dockerhub.
-This new OTP image will automatically use the graph and configuration from the storage location where the build's end result was stored at.
+  This new OTP image will automatically use the graph and configuration from the storage location where the build's end result was stored at.
 
 - `storage:cleanup` keeps the 10 latest versions of the data in storage and removes the rest.
 

--- a/README.md
+++ b/README.md
@@ -59,75 +59,145 @@ It is possible to change the behaviour of the data builder by defining environme
 - (Optional) "NOCLEANUP" can be used to disable removal of historical data in storage
 - (Optional) "JAVA_OPTS" Java parameters for running OTP
 
-#### Data processing steps
+### Data processing steps
 
-Seed data can be retrieved with a single gulp command:
-
-1. `seed`
+- `seed`
 
 Downloads previous data from storage (env variable SEED_TAG can be used to customize which storage location is used)
-and extracts osm, dem and gtfs data from there and places it in 'data/seed' and 'data/ready' directories.
-Old data acts as backup in case fetching/validating new data fails.
+and then extracts osm, dem, and gtfs data and places it in the `data/seed` and `data/ready` directories.
+The old data acts as backup in case fetching/validating new data fails. The command uses the zipped contents of the latest build that built a complete graph (from prebuilt data or with no split build).
 
-2. `osm:update`
+- `dem:update`
 
-This command downloads required OSM packages from configured location, tests the file(s) with otp,
-and if tests pass data is copied to 'data/downloads/osm' directory.
+This command downloads required DEM information, after which data is copied to the `data/downloads/dem` directory.
 
-The data is then processed with the following steps:
+- `osm:update`
 
-3. `gtfs:dl`
-   Downloads a GTFS package from configured location, tests the file with otp, if
-   test passes data is copied to directory 'data/fit/gtfs'. The resulting zip is named <feedid>.zip.
+This command downloads required OSM packages from configured locations, tests the files with OTP,
+and if the tests pass, data is copied to the `data/downloads/osm` directory.
 
-4. `gtfs:fit`
-   Runs configured map fits. Copies data to directory 'data/filter/gtfs'.
+- `gtfs:update`
+   - `gtfs:dl`
 
-5. `gtfs:filter`
-   Runs configured filterings. Copies data to directory 'data/id/gtfs'.
+   Downloads a GTFS package from a configured location and tests the file with OTP, if
+   the test passes data is copied to the `data/fit/gtfs` directory. The resulting zip file is named `<feedid>.zip`.
 
-6. `gtfs:id`
-   Sets the gtfs feed id to <id> and copies data to directory 'data/ready/gtfs'.
+   - `gtfs:fit`
 
-Steps 3. - 6. can also be run together using a single `gtfs:update` command.
+   Runs configured map fits. Copies data to the `data/filter/gtfs` directory.
 
-Building the router from available (seeded or downloaded and processed) data:
+   - `gtfs:filter`
 
-7. `router:buildGraph`
+   Runs configured filters. Copies data to the `data/id/gtfs` directory.
+
+   - `gtfs:id`
+
+   Sets the gtfs feed id to `<id>` and copies data to the `data/ready/gtfs` directory.
+
+- `router:buildGraph`
+   - `router:copy`
+   - `buildOTPGraphTask(config.router)`
 
 Builds a new graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
-8. `test.sh`
+- `router:buildStreetOnlyGraph`
+   - `router:copyStreetOnlyGraphData`
+   - `buildOTPStreetOnlyGraphTask(config.router)`
 
-Runs routing quality test bench defined in the repository 'hsldevcom/OTPQA'. OTPQA test sets are associated with GTFS packages.
-If there are quality regressions, a comma separated list of failed GTFS feed identifiers is is written to local file 'failed_feeds.txt'.
+Builds a new street only graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
-9. `router:store`
+- `router:buildWithPrebuiltStreetGraph`
+   - `router:copyForPrebuiltStreetGraphDataBuild`
+   - `buildOTPGraphTask(config.router)`
+
+Builds a new graph from prebuilt street only data with new gtfs data sets (and maybe seeded data sets if there were issues with new data).
+
+- `test.sh`
+
+Runs routing quality test bench defined in the repository `hsldevcom/OTPQA`. OTPQA test sets are associated with GTFS packages.
+If there are quality regressions, a comma separated list of failed GTFS feed identifiers is is written to local file `failed_feeds.txt`.
+
+- `router:store`
 
 Stores the new data in storage (which can be a mounted storage volume).
 
-10. `deploy.sh`
+- `router:storeForPrebuiltStreetGraphDataBuild`
 
-Deploys new opentripplanner-data-server image with 'DOCKER_TAG' env variable (default 'v3') postfixed with the router name and
+Stores the new data in storage (which can be a mounted storage volume). Also copies the `report` directory from the street only build to the output directory under the name `osm-report`.
+
+- `deploy.sh`
+
+Deploys a new opentripplanner-data-server image with the `DOCKER_TAG` env variable (default `v3`) postfixed with the router name, and
 pushes the image to Dockerhub.
 
-Normally, when the application is running as a container, the script 'index.js' is run to execute all steps 1 - 10 described above.
-The end result of the build is a data server image uploaded into dockerhub.
+Normally, when the application is running as a container, the script `index.js` is run to execute all steps.
+The end result of the build is a data server image uploaded to dockerhub.
 
-Each data server image runs a http server listening to port 8080, serving both a data bundle required for building a graph,
-and a pre-built graph. For example, in HSL case: http://localhost:8080/router-hsl.zip and graph-hsl-$OTPVERSION.zip. The image
+Each data server image runs a http server listening to port `8080`, serving both a data bundle required for building a graph,
+and a pre-built graph. For example, in the HSL case: http://localhost:8080/router-hsl.zip and `graph-hsl-$OTPVERSION.zip`. The image
 does not include the data, the data needs to be mounted while running the container.
 
-11. `deploy-otp.sh`
+- `deploy-otp.sh`
 
-Tags opentripplanner image with using 'OTP_TAG' env variable (default 'v3') postfixed with the router name and pushes the image to Dockerhub.
+Tags an OTP image using the `OTP_TAG` env variable (default `v3`) postfixed with the router name and pushes the image to Dockerhub.
 
-This new opentripplanner image will automatically use the graph and configuration from the storage location where the build's end result
+This new OTP image will automatically use the graph and configuration from the storage location where the build's end result
 was stored at.
 
-12. `storage:cleanup`
+- `storage:cleanup`
 
-Keeps 10 latest versions of the data in storage and removes the rest.
+Keeps the 10 latest versions of the data in storage and removes the rest.
+
+- `storage:cleanupStreetOnlyGraphData`
+
+Keeps 10 latest versions of the street only build data in storage and removes the rest.
+
+#### Normal build
+
+1. `seed`
+2. `dem:update`
+3. `osm:update`
+4. `gtfs:update`
+   - `gtfs:dl`
+   - `gtfs:fit`
+   - `gtfs:filter`
+   - `gtfs:id`
+5. `router:buildGraph`
+   - `router:copy`
+   - `buildOTPGraphTask(config.router)`
+6. `test.sh`
+7. `router:store`
+8. `deploy.sh`
+9. `deploy-otp.sh`
+10. `storage:cleanup`
+
+#### Street only build
+
+1. `seed`
+2. `dem:update`
+3. `osm:update`
+4. `router:buildStreetOnlyGraph`
+   - `router:copyStreetOnlyGraphData`
+   - `buildOTPStreetOnlyGraphTask(config.router)`
+5. `router:store`
+6. `storage:cleanupStreetOnlyGraphData`
+
+#### Build from prebuilt street data
+
+1. `seed`
+2. `gtfs:update`
+   - `gtfs:dl`
+   - `gtfs:fit`
+   - `gtfs:filter`
+   - `gtfs:id`
+3. `router:buildWithPrebuiltStreetGraph`
+   - `router:copyForPrebuiltStreetGraphDataBuild`
+   - `buildOTPGraphTask(config.router)`
+4. `test.sh`
+5. `router:storeForPrebuiltStreetGraphDataBuild`
+6. `deploy.sh`
+7. `deploy-otp.sh`
+8. `storage:cleanup`
 
 ### otp-data-tools
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ It is possible to change the behaviour of the data builder by defining environme
   pushes the image to Dockerhub.<p>
   Normally, when the application is running as a container, the script `index.js` is run to execute all steps.
   The end result of the build is a data server image uploaded to dockerhub.<p>
-  Each data server image runs an http server listening to port `8080`, serving both a data bundle required for building a graph,
-  and a pre-built graph. For example, in the HSL case: http://localhost:8080/router-hsl.zip and `graph-hsl-$OTPVERSION.zip`. The image
+  Each data server image runs an http server listening to port `8080`. It serves a data bundle required for building a graph and a prebuilt graph. For example, in the HSL case: http://localhost:8080/router-hsl.zip and `graph-hsl-$OTPVERSION.zip`. The image
   does not include the data, the data needs to be mounted while running the container.
 
 - `deploy-otp.sh` tags an OTP image using the `OTP_TAG` env variable (default `v2`) postfixed with the router name and pushes the image to Dockerhub.

--- a/README.md
+++ b/README.md
@@ -33,31 +33,35 @@ download new gtfs data for waltti:
 
 It is possible to change the behaviour of the data builder by defining environment variables.
 
-- "ROUTER_NAME" defines for which router the data gets updated for.
-- "DOCKER_USER" defines username for authenticating to docker hub.
-- "DOCKER_AUTH" defines password for authenticating to docker hub.
-- (Optional, default v3 and tag based on date) "DOCKER_TAG" defines what will be the updated docker tag of the data server images in the remote container registry.
-- (Optional, default hsldevcom) "ORG" defines what organization images belong to in the remote container registry.
-- (Optional, default v3) "SEED_TAG" defines what version of the data storage should be used for seeding.
-- (Optional, default v2) "OTP_TAG" defines what version of OTP is used for testing, building graphs and deploying a new OTP image (postfixed with router name).
-- (Optional, default v3) "TOOLS_TAG" defines what version of otp-data-tools image is used for testing.
-- (Optional, default dev) "BUILDER_TYPE" used as a postfix to slack bot name
-- (Optional) "SLACK_CHANNEL_ID" defines to which slack channel the messages are sent to
-- (Optional) "SLACK_ACCESS_TOKEN" bearer token for slack messaging
-- (Optional, default {}) "EXTRA_SRC" defines gtfs src values that should be overridden or completely new src that should be added with unique id. Example format:
+- `ROUTER_NAME` defines for which router the data gets updated for.
+- `DOCKER_USER` defines username for authenticating to docker hub.
+- `DOCKER_AUTH` defines password for authenticating to docker hub.
+- (Optional, default v3 and tag based on date) `DOCKER_TAG` defines what will be the updated docker tag of the data server images in the remote container registry.
+- (Optional, default hsldevcom) `ORG` defines what organization images belong to in the remote container registry.
+- (Optional, default v3) `SEED_TAG` defines what version of the data storage should be used for seeding.
+- (Optional, default v2) `OTP_TAG` defines what version of OTP is used for testing, building graphs and deploying a new OTP image (postfixed with router name).
+- (Optional, default v3) `TOOLS_TAG` defines what version of otp-data-tools image is used for testing.
+- (Optional, default dev) `BUILDER_TYPE` used as a postfix to slack bot name
+- (Optional) `SLACK_CHANNEL_ID` defines to which slack channel the messages are sent to
+- (Optional) `SLACK_ACCESS_TOKEN` bearer token for slack messaging
+- (Optional, default {}) `EXTRA_SRC` defines gtfs src values that should be overridden or completely new src that should be added with unique id. Example format:
   - `{"FOLI": {"url": "https://data.foli.fi/gtfs/gtfs.zip",  "fit": false, "rules": ["router-waltti/gtfs-rules/waltti.rule"]}}`
-  - You can remove a src by including "remove": true, `{"FOLI": {"remove": true}}`
-- (Optional, default {}) "EXTRA_UPDATERS" defines router-config.json updater values that should be overridden or completely new updater that should be added with unique id. Example format:
+  - You can remove a src by including `"remove": true`, `{"FOLI": {"remove": true}}`
+- (Optional, default {}) `EXTRA_UPDATERS` defines router-config.json updater values that should be overridden or completely new updater that should be added with unique id. Example format:
   - `{"turku-alerts": {"type": "real-time-alerts", "frequencySec": 30, "url": "https://foli-beta.nanona.fi/gtfs-rt/reittiopas", "feedId": "FOLI", "fuzzyTripMatching": true}}`
-  - You can remove a src by including "remove": true, `{"turku-alerts": {"remove": true}}`
-- (Optional, default {}) "EXTRA_OSM" can redefine OSM source URLs. For example: `{"hsl": "https://tempserver.com/newhsl.pbf"}`
-- (Optional) "VERSION_CHECK" is a comma-separated list of feedIds from which the GTFS data's `feed_info.txt`'s file's `feed_version` field is parsed into a date object and it's checked if the data has been updated within the last 8 hours. If not, a message is sent to stdout (and slack, only monday-friday) to inform about usage of "old" data.
-- (Optional) "SKIPPED_SITES" defines a comma-separated list of sites from OTPQA tests that should be skipped. Example format:
+  - You can remove a src by including `"remove": true`, `{"turku-alerts": {"remove": true}}`
+- (Optional, default {}) `EXTRA_OSM` can redefine OSM source URLs. For example: `{"hsl": "https://tempserver.com/newhsl.pbf"}`
+- (Optional) `VERSION_CHECK` is a comma-separated list of feedIds from which the GTFS data's `feed_info.txt`'s file's `feed_version` field is parsed into a date object and it's checked if the data has been updated within the last 8 hours. If not, a message is sent to stdout (and slack, only monday-friday) to inform about usage of "old" data.
+- (Optional) `SKIPPED_SITES` defines a comma-separated list of sites from OTPQA tests that should be skipped. Example format:
   - `"turku.digitransit.fi,reittiopas.hsl.fi"`
-- (Optional) "DISABLE_BLOB_VALIDATION" should be included if blob (OSM) validation should be disabled temporarily.
-- (Optional) "NOSEED" should be included (together with DISABLE_BLOB_VALIDATION) when data loading for a new configuration is run first time and no seed image is available.
-- (Optional) "NOCLEANUP" can be used to disable removal of historical data in storage
-- (Optional) "JAVA_OPTS" Java parameters for running OTP
+- (Optional) `DISABLE_BLOB_VALIDATION` should be included if blob (OSM) validation should be disabled temporarily.
+- (Optional) `NOSEED` should be included (together with DISABLE_BLOB_VALIDATION) when data loading for a new configuration is run first time and no seed image is available.
+- (Optional) `NOCLEANUP` can be used to disable removal of historical data in storage
+- (Optional) `JAVA_OPTS` Java parameters for running OTP
+- (Optional) `SPLIT_BUILD_TYPE` is an enum used to configure if the build should be split. The values are:
+  - `ONLY_BUILD_STREET_GRAPH` to only build the street graph
+  - `USE_PREBUILT_STREET_GRAPH` to use the prebuilt street graph to finish a complete graph build
+  - All other values default to `NO_SPLIT_BUILD` which indicates that the build is run as normal
 
 ### Data processing steps
 
@@ -65,7 +69,7 @@ It is possible to change the behaviour of the data builder by defining environme
 
 Downloads previous data from storage (env variable SEED_TAG can be used to customize which storage location is used)
 and then extracts osm, dem, and gtfs data and places it in the `data/seed` and `data/ready` directories.
-The old data acts as backup in case fetching/validating new data fails. The command uses the zipped contents of the latest build that built a complete graph (from prebuilt data or with no split build).
+The old data acts as backup in case fetching/validating new data fails. The command uses the zipped contents of the latest build that built a complete graph (from prebuilt data or from a normal build).
 
 - `dem:update`
 

--- a/README.md
+++ b/README.md
@@ -65,97 +65,59 @@ It is possible to change the behaviour of the data builder by defining environme
 
 ### Data processing steps
 
-- `seed`
-
-Downloads previous data from storage (env variable SEED_TAG can be used to customize which storage location is used)
+- `seed` downloads previous data from storage (env variable SEED_TAG can be used to customize which storage location is used)
 and then extracts osm, dem, and gtfs data and places it in the `data/seed` and `data/ready` directories.
 The old data acts as backup in case fetching/validating new data fails. The command uses the zipped contents of the latest build that built a complete graph (from prebuilt data or from a normal build).
 
-- `dem:update`
+- `dem:update` downloads required DEM information, after which data is copied to the `data/downloads/dem` directory.
 
-This command downloads required DEM information, after which data is copied to the `data/downloads/dem` directory.
-
-- `osm:update`
-
-This command downloads required OSM packages from configured locations, tests the files with OTP,
+- `osm:update` downloads required OSM packages from configured locations, tests the files with OTP,
 and if the tests pass, data is copied to the `data/downloads/osm` directory.
 
 - `gtfs:update`
 
-  - `gtfs:dl`
-
-  Downloads a GTFS package from a configured location and tests the file with OTP, if
+  - `gtfs:dl` downloads a GTFS package from a configured location and tests the file with OTP, if
   the test passes data is copied to the `data/fit/gtfs` directory. The resulting zip file is named `<feedid>.zip`.
 
-  - `gtfs:fit`
+  - `gtfs:fit` runs configured map fits. Copies data to the `data/filter/gtfs` directory.
 
-  Runs configured map fits. Copies data to the `data/filter/gtfs` directory.
+  - `gtfs:filter` runs configured filters. Copies data to the `data/id/gtfs` directory.
 
-  - `gtfs:filter`
-
-  Runs configured filters. Copies data to the `data/id/gtfs` directory.
-
-  - `gtfs:id`
-
-  Sets the gtfs feed id to `<id>` and copies data to the `data/ready/gtfs` directory.
+  - `gtfs:id` sets the gtfs feed id to `<id>` and copies data to the `data/ready/gtfs` directory.
 
 - `router:buildGraph`
-  - `router:copy`
-  - `buildOTPGraphTask(config.router)`
-
-Builds a new graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
+  - `router:copy` copies files needed for the build.
+  - `buildOTPGraphTask(config.router)` builds a new graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
 - `router:buildStreetOnlyGraph`
-  - `router:copyStreetOnlyGraphData`
-  - `buildOTPStreetOnlyGraphTask(config.router)`
-
-Builds a new street only graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
+  - `router:copyStreetOnlyGraphData` copies files needed for the street only build.
+  - `buildOTPStreetOnlyGraphTask(config.router)` builds a new street only graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
 - `router:buildWithPrebuiltStreetGraph`
-  - `router:copyForPrebuiltStreetGraphDataBuild`
-  - `buildOTPGraphTask(config.router)`
+  - `router:copyForPrebuiltStreetGraphDataBuild` copies files needed for the build from prebuilt data.
+  - `buildOTPGraphTask(config.router)` builds a new graph from prebuilt street only data with new gtfs data sets (and maybe seeded data sets if there were issues with new data).
 
-Builds a new graph from prebuilt street only data with new gtfs data sets (and maybe seeded data sets if there were issues with new data).
+- `test.sh` runs the routing quality test bench defined in the `hsldevcom/OTPQA` repository. OTPQA test sets are associated with GTFS packages.
+If there are quality regressions, a comma separated list of failed GTFS feed identifiers is written to the local file `failed_feeds.txt`.
 
-- `test.sh`
+- `router:store` stores the new data in storage (which can be a mounted storage volume).
 
-Runs routing quality test bench defined in the repository `hsldevcom/OTPQA`. OTPQA test sets are associated with GTFS packages.
-If there are quality regressions, a comma separated list of failed GTFS feed identifiers is is written to local file `failed_feeds.txt`.
+- `router:storeForPrebuiltStreetGraphDataBuild` stores the new data in storage (which can be a mounted storage volume). Also copies the `report` directory from the street only build to the output directory under the name `osm-report`.
 
-- `router:store`
-
-Stores the new data in storage (which can be a mounted storage volume).
-
-- `router:storeForPrebuiltStreetGraphDataBuild`
-
-Stores the new data in storage (which can be a mounted storage volume). Also copies the `report` directory from the street only build to the output directory under the name `osm-report`.
-
-- `deploy.sh`
-
-Deploys a new opentripplanner-data-server image with the `DOCKER_TAG` env variable (default `v3`) postfixed with the router name, and
-pushes the image to Dockerhub.
-
+- `deploy.sh` deploys a new opentripplanner-data-server image with the `DOCKER_TAG` env variable (default `v3`) postfixed with the router name, and
+pushes the image to Dockerhub.<p>
 Normally, when the application is running as a container, the script `index.js` is run to execute all steps.
-The end result of the build is a data server image uploaded to dockerhub.
-
+The end result of the build is a data server image uploaded to dockerhub.<p>
 Each data server image runs a http server listening to port `8080`, serving both a data bundle required for building a graph,
 and a pre-built graph. For example, in the HSL case: http://localhost:8080/router-hsl.zip and `graph-hsl-$OTPVERSION.zip`. The image
 does not include the data, the data needs to be mounted while running the container.
 
-- `deploy-otp.sh`
+- `deploy-otp.sh` tags an OTP image using the `OTP_TAG` env variable (default `v3`) postfixed with the router name and pushes the image to Dockerhub.
+This new OTP image will automatically use the graph and configuration from the storage location where the build's end result was stored at.
 
-Tags an OTP image using the `OTP_TAG` env variable (default `v3`) postfixed with the router name and pushes the image to Dockerhub.
+- `storage:cleanup` keeps the 10 latest versions of the data in storage and removes the rest.
 
-This new OTP image will automatically use the graph and configuration from the storage location where the build's end result
-was stored at.
-
-- `storage:cleanup`
-
-Keeps the 10 latest versions of the data in storage and removes the rest.
-
-- `storage:cleanupStreetOnlyGraphData`
-
-Keeps 10 latest versions of the street only build data in storage and removes the rest.
+- `storage:cleanupStreetOnlyGraphData` keeps the 10 latest versions of the street only build data in storage and removes the rest.
 
 #### Normal build
 

--- a/README.md
+++ b/README.md
@@ -77,38 +77,39 @@ This command downloads required OSM packages from configured locations, tests th
 and if the tests pass, data is copied to the `data/downloads/osm` directory.
 
 - `gtfs:update`
-   - `gtfs:dl`
 
-   Downloads a GTFS package from a configured location and tests the file with OTP, if
-   the test passes data is copied to the `data/fit/gtfs` directory. The resulting zip file is named `<feedid>.zip`.
+  - `gtfs:dl`
 
-   - `gtfs:fit`
+  Downloads a GTFS package from a configured location and tests the file with OTP, if
+  the test passes data is copied to the `data/fit/gtfs` directory. The resulting zip file is named `<feedid>.zip`.
 
-   Runs configured map fits. Copies data to the `data/filter/gtfs` directory.
+  - `gtfs:fit`
 
-   - `gtfs:filter`
+  Runs configured map fits. Copies data to the `data/filter/gtfs` directory.
 
-   Runs configured filters. Copies data to the `data/id/gtfs` directory.
+  - `gtfs:filter`
 
-   - `gtfs:id`
+  Runs configured filters. Copies data to the `data/id/gtfs` directory.
 
-   Sets the gtfs feed id to `<id>` and copies data to the `data/ready/gtfs` directory.
+  - `gtfs:id`
+
+  Sets the gtfs feed id to `<id>` and copies data to the `data/ready/gtfs` directory.
 
 - `router:buildGraph`
-   - `router:copy`
-   - `buildOTPGraphTask(config.router)`
+  - `router:copy`
+  - `buildOTPGraphTask(config.router)`
 
 Builds a new graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
 - `router:buildStreetOnlyGraph`
-   - `router:copyStreetOnlyGraphData`
-   - `buildOTPStreetOnlyGraphTask(config.router)`
+  - `router:copyStreetOnlyGraphData`
+  - `buildOTPStreetOnlyGraphTask(config.router)`
 
 Builds a new street only graph with all the new data sets (and maybe seeded data sets if there were issues with new data).
 
 - `router:buildWithPrebuiltStreetGraph`
-   - `router:copyForPrebuiltStreetGraphDataBuild`
-   - `buildOTPGraphTask(config.router)`
+  - `router:copyForPrebuiltStreetGraphDataBuild`
+  - `buildOTPGraphTask(config.router)`
 
 Builds a new graph from prebuilt street only data with new gtfs data sets (and maybe seeded data sets if there were issues with new data).
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If there are quality regressions, a comma separated list of failed GTFS feed ide
 
 - `router:store` stores the new data in storage (which can be a mounted storage volume).
 
-- `router:storeForPrebuiltStreetGraphDataBuild` stores the new data in storage (which can be a mounted storage volume). Also copies the `report` directory from the street only build to the output directory under the name `osm-report`.
+- `router:storeForPrebuiltStreetGraphDataBuild` stores the new data in storage (which can be a mounted storage volume). Also copies the `report` directory from the street only build to the output directory under the name `street-report`.
 
 - `deploy.sh` deploys a new opentripplanner-data-server image with the `DOCKER_TAG` env variable (default `v3`) postfixed with the router name, and
 pushes the image to Dockerhub.<p>

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ If there are quality regressions, a comma separated list of failed GTFS feed ide
 pushes the image to Dockerhub.<p>
 Normally, when the application is running as a container, the script `index.js` is run to execute all steps.
 The end result of the build is a data server image uploaded to dockerhub.<p>
-Each data server image runs a http server listening to port `8080`, serving both a data bundle required for building a graph,
+Each data server image runs an http server listening to port `8080`, serving both a data bundle required for building a graph,
 and a pre-built graph. For example, in the HSL case: http://localhost:8080/router-hsl.zip and `graph-hsl-$OTPVERSION.zip`. The image
 does not include the data, the data needs to be mounted while running the container.
 
-- `deploy-otp.sh` tags an OTP image using the `OTP_TAG` env variable (default `v3`) postfixed with the router name and pushes the image to Dockerhub.
+- `deploy-otp.sh` tags an OTP image using the `OTP_TAG` env variable (default `v2`) postfixed with the router name and pushes the image to Dockerhub.
 This new OTP image will automatically use the graph and configuration from the storage location where the build's end result was stored at.
 
 - `storage:cleanup` keeps the 10 latest versions of the data in storage and removes the rest.

--- a/config.js
+++ b/config.js
@@ -15,6 +15,8 @@ const router = require(`./${process.env.ROUTER_NAME}/config`);
 const extraSrc =
   process.env.EXTRA_SRC !== undefined ? JSON.parse(process.env.EXTRA_SRC) : {};
 
+const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || 'NO_SPLIT_BUILD';
+
 const usedSrc = [];
 
 // override source values if they are defined in extraSrc
@@ -89,4 +91,5 @@ module.exports = {
   storageDir: `${process.cwd()}/storage`,
   constants,
   passOBAfilter,
+  SPLIT_BUILD_TYPE,
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -283,3 +283,7 @@ gulp.task('router:store', () =>
 gulp.task('storage:cleanup', () =>
   storageCleanup(config.storageDir, config.router.id, process.env.SEED_TAG),
 );
+
+gulp.task('storage:cleanupOnlyStreetGraphData', () =>
+  storageCleanup(config.storageDir, config.router.id, `osm-builds/${process.env.SEED_TAG}`),
+);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -294,8 +294,8 @@ gulp.task('router:store', () =>
 gulp.task('router:storeForPrebuiltStreetGraphDataBuild', 
   gulp.series('router:store', () =>
     gulp
-      .src(`${global.osmPrebuildDir}/reports/*`, { buffer: false })
-      .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/osm-reports/`)),
+      .src(`${global.osmPrebuildDir}/report/*`, { buffer: false })
+      .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/osm-report/`)),
   ),
 );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -291,11 +291,14 @@ gulp.task('router:store', () =>
     .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/`)),
 );
 
-gulp.task('router:storeForPrebuiltStreetGraphDataBuild', 
+gulp.task(
+  'router:storeForPrebuiltStreetGraphDataBuild',
   gulp.series('router:store', () =>
     gulp
       .src(`${global.osmPrebuildDir}/report/*`, { buffer: false })
-      .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/osm-report/`)),
+      .pipe(
+        gulp.dest(`${config.storageDir}/${global.storageDirName}/osm-report/`),
+      ),
   ),
 );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -282,7 +282,7 @@ gulp.task('router:store', () =>
 
 gulp.task('router:storeOnlyStreetGraphData', () =>
   gulp
-    .src(`${config.dataDir}/build/osm-builds/${config.router.id}/streetGraph.obj`, { buffer: false })
+    .src(`${config.dataDir}/build/${config.router.id}/streetGraph.obj`, { buffer: false })
     .pipe(gulp.dest(`${config.storageDir}/osm-builds/${global.storageDirName}/`)),
 );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,10 +10,17 @@ const mapFit = require('./task/MapFit');
 const { validateBlobSize } = require('./task/BlobValidation');
 const { testOTPFile } = require('./task/OTPTest');
 const seed = require('./task/Seed');
-const { prepareRouterData, prepareRouterDataForStreetOnlyGraphBuild, prepareRouterDataForPrebuiltStreetGraphBuild } = require('./task/PrepareRouterData');
+const {
+  prepareRouterData,
+  prepareRouterDataForStreetOnlyGraphBuild,
+  prepareRouterDataForPrebuiltStreetGraphBuild,
+} = require('./task/PrepareRouterData');
 const del = require('del');
 const config = require('./config');
-const { buildOTPGraphTask, buildOTPStreetOnlyGraphTask } = require('./task/BuildOTPGraph');
+const {
+  buildOTPGraphTask,
+  buildOTPStreetOnlyGraphTask,
+} = require('./task/BuildOTPGraph');
 const { renameGTFSFile } = require('./task/GTFSRename');
 const { replaceGTFSFilesTask } = require('./task/GTFSReplace');
 const { extractFromZip, addToZip } = require('./task/ZipTask');
@@ -257,7 +264,9 @@ gulp.task(
 
 gulp.task(
   'router:buildWithPrebuiltStreetGraph',
-  gulp.series('router:copyForPrebuiltStreetGraphDataBuild', () => buildOTPGraphTask(config.router)),
+  gulp.series('router:copyForPrebuiltStreetGraphDataBuild', () =>
+    buildOTPGraphTask(config.router),
+  ),
 );
 
 gulp.task(
@@ -271,7 +280,9 @@ gulp.task(
 
 gulp.task(
   'router:buildStreetOnlyGraph',
-  gulp.series('router:copyStreetOnlyGraphData', () => buildOTPStreetOnlyGraphTask(config.router)),
+  gulp.series('router:copyStreetOnlyGraphData', () =>
+    buildOTPStreetOnlyGraphTask(config.router),
+  ),
 );
 
 gulp.task('router:store', () =>
@@ -285,5 +296,9 @@ gulp.task('storage:cleanup', () =>
 );
 
 gulp.task('storage:cleanupStreetOnlyGraphData', () =>
-  storageCleanup(config.storageDir, config.router.id, `osm-builds/${process.env.SEED_TAG}`),
+  storageCleanup(
+    config.storageDir,
+    config.router.id,
+    `osm-builds/${process.env.SEED_TAG}`,
+  ),
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -291,6 +291,14 @@ gulp.task('router:store', () =>
     .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/`)),
 );
 
+gulp.task('router:storeForPrebuiltStreetGraphDataBuild', 
+  gulp.series('router:store', () =>
+    gulp
+      .src(`${global.osmPrebuildDir}/reports/*`, { buffer: false })
+      .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/osm-reports/`)),
+  ),
+);
+
 gulp.task('storage:cleanup', () =>
   storageCleanup(config.storageDir, config.router.id, process.env.SEED_TAG),
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -280,12 +280,6 @@ gulp.task('router:store', () =>
     .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/`)),
 );
 
-gulp.task('router:storeOnlyStreetGraphData', () =>
-  gulp
-    .src(`${config.dataDir}/build/${config.router.id}/streetGraph.obj`, { buffer: false })
-    .pipe(gulp.dest(`${config.storageDir}/osm-builds/${global.storageDirName}/`)),
-);
-
 gulp.task('storage:cleanup', () =>
   storageCleanup(config.storageDir, config.router.id, process.env.SEED_TAG),
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,10 +10,10 @@ const mapFit = require('./task/MapFit');
 const { validateBlobSize } = require('./task/BlobValidation');
 const { testOTPFile } = require('./task/OTPTest');
 const seed = require('./task/Seed');
-const { prepareRouterData, prepareRouterDataForOnlyStreetGraphBuild, prepareRouterDataForPrebuiltStreetGraphBuild } = require('./task/PrepareRouterData');
+const { prepareRouterData, prepareRouterDataForStreetOnlyGraphBuild, prepareRouterDataForPrebuiltStreetGraphBuild } = require('./task/PrepareRouterData');
 const del = require('del');
 const config = require('./config');
-const { buildOTPGraphTask, buildOTPOnlyStreetGraphTask } = require('./task/BuildOTPGraph');
+const { buildOTPGraphTask, buildOTPStreetOnlyGraphTask } = require('./task/BuildOTPGraph');
 const { renameGTFSFile } = require('./task/GTFSRename');
 const { replaceGTFSFilesTask } = require('./task/GTFSReplace');
 const { extractFromZip, addToZip } = require('./task/ZipTask');
@@ -261,17 +261,17 @@ gulp.task(
 );
 
 gulp.task(
-  'router:copyOnlyStreetGraphData',
+  'router:copyStreetOnlyGraphData',
   gulp.series('router:del', () =>
-    prepareRouterDataForOnlyStreetGraphBuild(config.router).pipe(
+    prepareRouterDataForStreetOnlyGraphBuild(config.router).pipe(
       gulp.dest(`${config.dataDir}/build/${config.router.id}`),
     ),
   ),
 );
 
 gulp.task(
-  'router:buildOnlyStreetGraph',
-  gulp.series('router:copyOnlyStreetGraphData', () => buildOTPOnlyStreetGraphTask(config.router)),
+  'router:buildStreetOnlyGraph',
+  gulp.series('router:copyStreetOnlyGraphData', () => buildOTPStreetOnlyGraphTask(config.router)),
 );
 
 gulp.task('router:store', () =>
@@ -284,6 +284,6 @@ gulp.task('storage:cleanup', () =>
   storageCleanup(config.storageDir, config.router.id, process.env.SEED_TAG),
 );
 
-gulp.task('storage:cleanupOnlyStreetGraphData', () =>
+gulp.task('storage:cleanupStreetOnlyGraphData', () =>
   storageCleanup(config.storageDir, config.router.id, `osm-builds/${process.env.SEED_TAG}`),
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -297,7 +297,7 @@ gulp.task(
     gulp
       .src(`${global.osmPrebuildDir}/report/*`, { buffer: false })
       .pipe(
-        gulp.dest(`${config.storageDir}/${global.storageDirName}/osm-report/`),
+        gulp.dest(`${config.storageDir}/${global.storageDirName}/street-report/`),
       ),
   ),
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -297,7 +297,9 @@ gulp.task(
     gulp
       .src(`${global.osmPrebuildDir}/report/*`, { buffer: false })
       .pipe(
-        gulp.dest(`${config.storageDir}/${global.storageDirName}/street-report/`),
+        gulp.dest(
+          `${config.storageDir}/${global.storageDirName}/street-report/`,
+        ),
       ),
   ),
 );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,10 +10,10 @@ const mapFit = require('./task/MapFit');
 const { validateBlobSize } = require('./task/BlobValidation');
 const { testOTPFile } = require('./task/OTPTest');
 const seed = require('./task/Seed');
-const prepareRouterData = require('./task/PrepareRouterData');
+const { prepareRouterData, prepareRouterDataForOnlyStreetGraphBuild, prepareRouterDataForPrebuiltStreetGraphBuild } = require('./task/PrepareRouterData');
 const del = require('del');
 const config = require('./config');
-const { buildOTPGraphTask } = require('./task/BuildOTPGraph');
+const { buildOTPGraphTask, buildOTPOnlyStreetGraphTask } = require('./task/BuildOTPGraph');
 const { renameGTFSFile } = require('./task/GTFSRename');
 const { replaceGTFSFilesTask } = require('./task/GTFSReplace');
 const { extractFromZip, addToZip } = require('./task/ZipTask');
@@ -246,10 +246,44 @@ gulp.task(
   gulp.series('router:copy', () => buildOTPGraphTask(config.router)),
 );
 
+gulp.task(
+  'router:copyForPrebuiltStreetGraphDataBuild',
+  gulp.series('router:del', () =>
+    prepareRouterDataForPrebuiltStreetGraphBuild(config.router).pipe(
+      gulp.dest(`${config.dataDir}/build/${config.router.id}`),
+    ),
+  ),
+);
+
+gulp.task(
+  'router:buildWithPrebuiltStreetGraph',
+  gulp.series('router:copyForPrebuiltStreetGraphDataBuild', () => buildOTPGraphTask(config.router)),
+);
+
+gulp.task(
+  'router:copyOnlyStreetGraphData',
+  gulp.series('router:del', () =>
+    prepareRouterDataForOnlyStreetGraphBuild(config.router).pipe(
+      gulp.dest(`${config.dataDir}/build/${config.router.id}`),
+    ),
+  ),
+);
+
+gulp.task(
+  'router:buildOnlyStreetGraph',
+  gulp.series('router:copyOnlyStreetGraphData', () => buildOTPOnlyStreetGraphTask(config.router)),
+);
+
 gulp.task('router:store', () =>
   gulp
     .src(`${config.dataDir}/build/${config.router.id}/**/*`, { buffer: false })
     .pipe(gulp.dest(`${config.storageDir}/${global.storageDirName}/`)),
+);
+
+gulp.task('router:storeOnlyStreetGraphData', () =>
+  gulp
+    .src(`${config.dataDir}/build/osm-builds/${config.router.id}/streetGraph.obj`, { buffer: false })
+    .pipe(gulp.dest(`${config.storageDir}/osm-builds/${global.storageDirName}/`)),
 );
 
 gulp.task('storage:cleanup', () =>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { postSlackMessage } = require('./util');
 const { update } = require('./task/Update');
-const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || 'NO_SPLIT_BUILD';
+const { SPLIT_BUILD_TYPE } = require('./config.js');
 
 let message = '';
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,22 @@
 const { postSlackMessage } = require('./util');
 const { update } = require('./task/Update');
+const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || 'NO_SPLIT_BUILD';
 
-postSlackMessage('Starting data build')
+let message = '';
+
+switch (SPLIT_BUILD_TYPE) {
+  case 'ONLY_BUILD_STREET_GRAPH':
+    message = 'Starting street only graph data build'
+    break;
+  case 'USE_PREBUILT_STREET_GRAPH':
+    message = 'Starting graph data build from prebuilt street graph'
+    break;
+  default:
+    message = 'Starting data build'
+    break;
+}
+
+postSlackMessage(message)
   .then(response => {
     if (response.ok) {
       global.messageTimeStamp = response.ts;

--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ let message = '';
 
 switch (SPLIT_BUILD_TYPE) {
   case 'ONLY_BUILD_STREET_GRAPH':
-    message = 'Starting street only graph data build'
+    message = 'Starting street only graph data build';
     break;
   case 'USE_PREBUILT_STREET_GRAPH':
-    message = 'Starting graph data build from prebuilt street graph'
+    message = 'Starting graph data build from prebuilt street graph';
     break;
   default:
-    message = 'Starting data build'
+    message = 'Starting data build';
     break;
 }
 

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -5,8 +5,10 @@ const { zipWithGlob, otpMatching, postSlackMessage } = require('../util');
 const { dataDir, constants } = require('../config.js');
 const graphBuildTag = process.env.OTP_TAG || 'v2';
 const JAVA_OPTS = process.env.JAVA_OPTS || '-Xmx12g';
-const ONLY_BUILD_STREET_GRAPH = process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
-const USE_PREBUILT_STREET_GRAPH = process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const ONLY_BUILD_STREET_GRAPH =
+  process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const USE_PREBUILT_STREET_GRAPH =
+  process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
 const dockerImage = `hsldevcom/opentripplanner:${graphBuildTag}`;
 
 const buildGraph = function (router) {
@@ -133,6 +135,7 @@ module.exports = {
       .then(() => del(`${dataDir}/build/${router.id}/taggedStops.log`))
       .then(() => process.stdout.write('Graph build SUCCESS\n')),
   buildOTPStreetOnlyGraphTask: router =>
-    buildGraph(router)
-      .then(() => process.stdout.write('Street only graph build SUCCESS\n')),
+    buildGraph(router).then(() =>
+      process.stdout.write('Street only graph build SUCCESS\n'),
+    ),
 };

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -5,7 +5,7 @@ const { zipWithGlob, otpMatching, postSlackMessage } = require('../util');
 const { dataDir, constants } = require('../config.js');
 const graphBuildTag = process.env.OTP_TAG || 'v2';
 const JAVA_OPTS = process.env.JAVA_OPTS || '-Xmx12g';
-const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || '';
+const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || 'NO_SPLIT_BUILD';
 const dockerImage = `hsldevcom/opentripplanner:${graphBuildTag}`;
 
 const buildGraph = function (router) {
@@ -22,13 +22,16 @@ const buildGraph = function (router) {
     );
     const commit = version.toString().match(/commit: ([0-9a-f]+)/)[1];
 
-    let command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --build --save`;
+    let command = null;
     switch (SPLIT_BUILD_TYPE) {
       case 'ONLY_BUILD_STREET_GRAPH':
         command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --buildStreet --save`;
         break;
       case 'USE_PREBUILT_STREET_GRAPH':
         command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --loadStreet --save`;
+        break;
+      default:
+        command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --build --save`;
         break;
     }
 

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -22,7 +22,7 @@ const buildGraph = function (router) {
     );
     const commit = version.toString().match(/commit: ([0-9a-f]+)/)[1];
 
-    let command = null;
+    let command;
     switch (SPLIT_BUILD_TYPE) {
       case 'ONLY_BUILD_STREET_GRAPH':
         command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --buildStreet --save`;

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -2,10 +2,9 @@ const fs = require('fs');
 const { exec, execSync } = require('child_process');
 const del = require('del');
 const { zipWithGlob, otpMatching, postSlackMessage } = require('../util');
-const { dataDir, constants } = require('../config.js');
+const { dataDir, constants, SPLIT_BUILD_TYPE } = require('../config.js');
 const graphBuildTag = process.env.OTP_TAG || 'v2';
 const JAVA_OPTS = process.env.JAVA_OPTS || '-Xmx12g';
-const { SPLIT_BUILD_TYPE } = require('./config.js');
 const dockerImage = `hsldevcom/opentripplanner:${graphBuildTag}`;
 
 const buildGraph = function (router) {

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -5,7 +5,7 @@ const { zipWithGlob, otpMatching, postSlackMessage } = require('../util');
 const { dataDir, constants } = require('../config.js');
 const graphBuildTag = process.env.OTP_TAG || 'v2';
 const JAVA_OPTS = process.env.JAVA_OPTS || '-Xmx12g';
-const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || 'NO_SPLIT_BUILD';
+const { SPLIT_BUILD_TYPE } = require('./config.js');
 const dockerImage = `hsldevcom/opentripplanner:${graphBuildTag}`;
 
 const buildGraph = function (router) {

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -5,10 +5,7 @@ const { zipWithGlob, otpMatching, postSlackMessage } = require('../util');
 const { dataDir, constants } = require('../config.js');
 const graphBuildTag = process.env.OTP_TAG || 'v2';
 const JAVA_OPTS = process.env.JAVA_OPTS || '-Xmx12g';
-const ONLY_BUILD_STREET_GRAPH =
-  process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
-const USE_PREBUILT_STREET_GRAPH =
-  process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || '';
 const dockerImage = `hsldevcom/opentripplanner:${graphBuildTag}`;
 
 const buildGraph = function (router) {
@@ -26,10 +23,13 @@ const buildGraph = function (router) {
     const commit = version.toString().match(/commit: ([0-9a-f]+)/)[1];
 
     let command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --build --save`;
-    if (ONLY_BUILD_STREET_GRAPH) {
-      command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --buildStreet --save`;
-    } else if (USE_PREBUILT_STREET_GRAPH) {
-      command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --loadStreet --save`;
+    switch (SPLIT_BUILD_TYPE) {
+      case 'ONLY_BUILD_STREET_GRAPH':
+        command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --buildStreet --save`;
+        break;
+      case 'USE_PREBUILT_STREET_GRAPH':
+        command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --loadStreet --save`;
+        break;
     }
 
     const buildGraph = exec(command, { maxBuffer: constants.BUFFER_SIZE });

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -5,6 +5,8 @@ const { zipWithGlob, otpMatching, postSlackMessage } = require('../util');
 const { dataDir, constants } = require('../config.js');
 const graphBuildTag = process.env.OTP_TAG || 'v2';
 const JAVA_OPTS = process.env.JAVA_OPTS || '-Xmx12g';
+const ONLY_BUILD_STREET_GRAPH = process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const USE_PREBUILT_STREET_GRAPH = process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
 const dockerImage = `hsldevcom/opentripplanner:${graphBuildTag}`;
 
 const buildGraph = function (router) {
@@ -21,7 +23,13 @@ const buildGraph = function (router) {
     );
     const commit = version.toString().match(/commit: ([0-9a-f]+)/)[1];
 
-    const command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --build --save`;
+    let command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --build --save`;
+    if (ONLY_BUILD_STREET_GRAPH) {
+      command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --buildStreet --save`;
+    } else if (USE_PREBUILT_STREET_GRAPH) {
+      command = `docker run -e JAVA_OPTS="${JAVA_OPTS}" -v ${dataDir}/build/${router.id}:/var/opentripplanner --mount type=bind,source=${dataDir}/../logback-include-extensions.xml,target=/logback-include-extensions.xml ${dockerImage} --loadStreet --save`;
+    }
+
     const buildGraph = exec(command, { maxBuffer: constants.BUFFER_SIZE });
     const buildLog = fs.openSync(
       `${dataDir}/build/${router.id}/build.log`,
@@ -124,4 +132,7 @@ module.exports = {
       .then(() => otpMatching(`${dataDir}/build/${router.id}`))
       .then(() => del(`${dataDir}/build/${router.id}/taggedStops.log`))
       .then(() => process.stdout.write('Graph build SUCCESS\n')),
+  buildOTPOnlyStreetGraphTask: router =>
+    buildGraph(router)
+      .then(() => process.stdout.write('Street only graph build SUCCESS\n')),
 };

--- a/task/BuildOTPGraph.js
+++ b/task/BuildOTPGraph.js
@@ -132,7 +132,7 @@ module.exports = {
       .then(() => otpMatching(`${dataDir}/build/${router.id}`))
       .then(() => del(`${dataDir}/build/${router.id}/taggedStops.log`))
       .then(() => process.stdout.write('Graph build SUCCESS\n')),
-  buildOTPOnlyStreetGraphTask: router =>
+  buildOTPStreetOnlyGraphTask: router =>
     buildGraph(router)
       .then(() => process.stdout.write('Street only graph build SUCCESS\n')),
 };

--- a/task/OTPTest.js
+++ b/task/OTPTest.js
@@ -8,7 +8,7 @@ const testTag = process.env.OTP_TAG || 'v2';
 const JAVA_OPTS = process.env.JAVA_OPTS || '-Xmx9g';
 
 /**
- * Builds an OTP graph with a source data file. If the build is succesful we can trust
+ * Builds an OTP graph with a source data file. If the build is successful we can trust
  * the file is good enough to be used.
  */
 function testWithOTP(otpFile, quiet = false) {

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -90,7 +90,7 @@ function prepareRouterData(router) {
 /**
  * Make router data ready for the street only graph build in opentripplanner.
  */
-function prepareRouterDataForStreetOnlyGraphBuild (router) {
+function prepareRouterDataForStreetOnlyGraphBuild(router) {
   const stream = through.obj();
 
   process.stdout.write(
@@ -115,19 +115,19 @@ function prepareRouterDataForStreetOnlyGraphBuild (router) {
 
 function getDirectories(path) {
   const directoryContents = fs.readdirSync(path);
-  const directories = directoryContents.filter((element) => {
+  const directories = directoryContents.filter(element => {
     return fs.statSync(path + '/' + element).isDirectory();
-  })
+  });
   return directories;
 }
 
 /**
  * Make router data ready for the street only graph build in opentripplanner.
  */
-function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
+function prepareRouterDataForPrebuiltStreetGraphBuild(router) {
   // check environmental variables which needs to be defined
   assert(process.env.DOCKER_TAG !== undefined, 'DOCKER_TAG must be defined');
-  
+
   const stream = through.obj();
 
   process.stdout.write(
@@ -142,13 +142,15 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
     stream.push(createFile(router, name, `${dataDir}/ready/gtfs`));
   });
 
-  const osmDirectories = getDirectories(`${storageDir}/osm-builds/${process.env.DOCKER_TAG}`);
+  const osmDirectories = getDirectories(
+    `${storageDir}/osm-builds/${process.env.DOCKER_TAG}`,
+  );
   if (osmDirectories.length > 0) {
-    osmDirectories.sort((date1, date2) => dirNameToDate(date2) - dirNameToDate(date1));
-    const osmPath = `${storageDir}/osm-builds/${process.env.DOCKER_TAG}/${osmDirectories[0]}/${router.id}`;
-    process.stdout.write(
-      `Using OSM data from ${osmPath} \n`,
+    osmDirectories.sort(
+      (date1, date2) => dirNameToDate(date2) - dirNameToDate(date1),
     );
+    const osmPath = `${storageDir}/osm-builds/${process.env.DOCKER_TAG}/${osmDirectories[0]}/${router.id}`;
+    process.stdout.write(`Using OSM data from ${osmPath} \n`);
     // This is needed for gtfs data fitting and seeding.
     router.osm.forEach(osmId => {
       const name = osmId + '.pbf';
@@ -162,14 +164,13 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
     // This is the prebuilt street graph.
     stream.push(createFile(router, 'streetGraph.obj', osmPath));
   } else {
-    throw new Error(`No OSM directories can be found!\n`)
+    throw new Error(`No OSM directories can be found!\n`);
   }
-  
+
   stream.end();
 
   return stream;
 }
-
 
 module.exports = {
   prepareRouterData,

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -123,6 +123,9 @@ function getDirectories(path) {
  * Make router data ready for the street only graph build in opentripplanner.
  */
 function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
+  // check environmental variables which needs to be defined
+  assert(process.env.DOCKER_TAG !== undefined, 'DOCKER_TAG must be defined');
+  
   const stream = through.obj();
 
   process.stdout.write(
@@ -137,13 +140,14 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
     stream.push(createFile(router, name, `${dataDir}/ready/gtfs`));
   });
 
-  const osmDirectories = getDirectories(`${storageDir}/osm-builds`);
+  const osmDirectories = getDirectories(`${storageDir}/osm-builds/${process.env.DOCKER_TAG}`);
   if (osmDirectories.length > 0) {
     osmDirectories.sort((date1, date2) => new Date(date2.replace(/./g, ':')) - new Date(date1.replace(/./g, ':')));
+    const osmPath = `${storageDir}/osm-builds/${process.env.DOCKER_TAG}/${osmDirectories[0]}/${router.id}`;
     process.stdout.write(
-      `Using OSM data from ${osmDirectories[0]} \n`,
+      `Using OSM data from ${osmPath} \n`,
     );
-    stream.push(createFile(router, 'streetGraph.obj', `${storageDir}/osm-builds/${osmDirectories[0]}/${router.id}/streetGraph.obj`));
+    stream.push(createFile(router, 'streetGraph.obj', osmPath));
   } else {
     throw new Error(`No OSM directories can be found exist!\n`)
   }

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -59,6 +59,7 @@ function createAndProcessRouterConfig(router) {
 
 /**
  * Make router data ready for inclusion in opentripplanner.
+ * In the whole build case, all osm, dem, and gtfs data is fetched from the data directory.
  */
 function prepareRouterData(router) {
   const stream = through.obj();
@@ -89,6 +90,7 @@ function prepareRouterData(router) {
 
 /**
  * Make router data ready for the street only graph build in opentripplanner.
+ * In the street only build case, only osm and dem data is fetched from the data directory, gtfs data is not fetched at all.
  */
 function prepareRouterDataForStreetOnlyGraphBuild(router) {
   const stream = through.obj();
@@ -123,6 +125,8 @@ function getDirectories(path) {
 
 /**
  * Make router data ready for the street only graph build in opentripplanner.
+ * In the prebuilt build case, only gtfs data is fetched from the data directory,
+ * osm and dem data, as well as the prebuilt streetGraph.obj file is fetched from the osm-builds directory.
  */
 function prepareRouterDataForPrebuiltStreetGraphBuild(router) {
   // check environmental variables which needs to be defined

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -153,20 +153,20 @@ function prepareRouterDataForPrebuiltStreetGraphBuild(router) {
     osmDirectories.sort(
       (date1, date2) => dirNameToDate(date2) - dirNameToDate(date1),
     );
-    const osmPath = `${storageDir}/osm-builds/${process.env.DOCKER_TAG}/${osmDirectories[0]}/${router.id}`;
-    process.stdout.write(`Using OSM data from ${osmPath} \n`);
+    global.osmPrebuildDir = `${storageDir}/osm-builds/${process.env.DOCKER_TAG}/${osmDirectories[0]}/${router.id}`;
+    process.stdout.write(`Using OSM data from ${global.osmPrebuildDir} \n`);
     // This is needed for gtfs data fitting and seeding.
     router.osm.forEach(osmId => {
       const name = osmId + '.pbf';
-      stream.push(createFile(router, name, osmPath));
+      stream.push(createFile(router, name, global.osmPrebuildDir));
     });
     // This is needed for seeding.
     if (router.dem) {
       const name = router.dem + '.tif';
-      stream.push(createFile(router, name, osmPath));
+      stream.push(createFile(router, name, global.osmPrebuildDir));
     }
     // This is the prebuilt street graph.
-    stream.push(createFile(router, 'streetGraph.obj', osmPath));
+    stream.push(createFile(router, 'streetGraph.obj', global.osmPrebuildDir));
   } else {
     throw new Error(`No OSM directories can be found!\n`);
   }

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -3,6 +3,7 @@ const Vinyl = require('vinyl');
 const fs = require('fs');
 const cloneable = require('cloneable-readable');
 const { dataDir, storageDir } = require('../config');
+const assert = require('assert');
 
 function createFile(config, fileName, sourcePath) {
   process.stdout.write(`copying ${fileName}...\n`);

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -90,11 +90,11 @@ function prepareRouterData(router) {
 /**
  * Make router data ready for the street only graph build in opentripplanner.
  */
-function prepareRouterDataForOnlyStreetGraphBuild (router) {
+function prepareRouterDataForStreetOnlyGraphBuild (router) {
   const stream = through.obj();
 
   process.stdout.write(
-    'Collecting data and configuration files for only street graph build\n',
+    'Collecting data and configuration files for street only graph build\n',
   );
 
   stream.push(createFile(router, 'build-config.json', router.id));
@@ -173,6 +173,6 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
 
 module.exports = {
   prepareRouterData,
-  prepareRouterDataForOnlyStreetGraphBuild,
+  prepareRouterDataForStreetOnlyGraphBuild,
   prepareRouterDataForPrebuiltStreetGraphBuild,
 };

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -148,6 +148,12 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
     process.stdout.write(
       `Using OSM data from ${osmPath} \n`,
     );
+    // This is needed for gtfs data fitting.
+    router.osm.forEach(osmId => {
+      const name = osmId + '.pbf';
+      stream.push(createFile(router, name, osmPath));
+    });
+    // This is the prebuilt street graph.
     stream.push(createFile(router, 'streetGraph.obj', osmPath));
   } else {
     throw new Error(`No OSM directories can be found exist!\n`)

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -143,7 +143,7 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
 
   const osmDirectories = getDirectories(`${storageDir}/osm-builds/${process.env.DOCKER_TAG}`);
   if (osmDirectories.length > 0) {
-    osmDirectories.sort((date1, date2) => new Date(date2.replace(/./g, ':')) - new Date(date1.replace(/./g, ':')));
+    osmDirectories.sort((date1, date2) => new Date(date1.replace(/./g, ':')) - new Date(date2.replace(/./g, ':')));
     const osmPath = `${storageDir}/osm-builds/${process.env.DOCKER_TAG}/${osmDirectories[0]}/${router.id}`;
     process.stdout.write(
       `Using OSM data from ${osmPath} \n`,

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -2,7 +2,7 @@ const through = require('through2');
 const Vinyl = require('vinyl');
 const fs = require('fs');
 const cloneable = require('cloneable-readable');
-const { dataDir } = require('../config');
+const { dataDir, storageDir } = require('../config');
 
 function createFile(config, fileName, sourcePath) {
   process.stdout.write(`copying ${fileName}...\n`);
@@ -58,7 +58,7 @@ function createAndProcessRouterConfig(router) {
 /**
  * Make router data ready for inclusion in opentripplanner.
  */
-module.exports = function (router) {
+function prepareRouterData(router) {
   const stream = through.obj();
 
   process.stdout.write(
@@ -83,4 +83,79 @@ module.exports = function (router) {
   stream.end();
 
   return stream;
+}
+
+/**
+ * Make router data ready for the street only graph build in opentripplanner.
+ */
+function prepareRouterDataForOnlyStreetGraphBuild (router) {
+  const stream = through.obj();
+
+  process.stdout.write(
+    'Collecting data and configuration files for only street graph build\n',
+  );
+
+  stream.push(createFile(router, 'build-config.json', router.id));
+  stream.push(createFile(router, 'otp-config.json', router.id));
+  stream.push(createAndProcessRouterConfig(router));
+  router.osm.forEach(osmId => {
+    const name = osmId + '.pbf';
+    stream.push(createFile(router, name, `${dataDir}/ready/osm`));
+  });
+  if (router.dem) {
+    const name = router.dem + '.tif';
+    stream.push(createFile(router, name, `${dataDir}/ready/dem`));
+  }
+  stream.end();
+
+  return stream;
+}
+
+function getDirectories(path) {
+  const directoryContents = fs.readdirSync(path);
+  const directories = directoryContents.filter((element) => {
+    return fs.statSync(path + '/' + element).isDirectory();
+  })
+  return directories;
+}
+
+/**
+ * Make router data ready for the street only graph build in opentripplanner.
+ */
+function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
+  const stream = through.obj();
+
+  process.stdout.write(
+    'Collecting data and configuration files for graph build based on prebuilt street graph data\n',
+  );
+
+  stream.push(createFile(router, 'build-config.json', router.id));
+  stream.push(createFile(router, 'otp-config.json', router.id));
+  stream.push(createAndProcessRouterConfig(router));
+  router.src.forEach(src => {
+    const name = src.id + '-gtfs.zip';
+    stream.push(createFile(router, name, `${dataDir}/ready/gtfs`));
+  });
+
+  const osmDirectories = getDirectories(`${storageDir}/osm-builds`);
+  if (osmDirectories.length > 0) {
+    osmDirectories.sort((date1, date2) => new Date(date2.replace(/./g, ':')) - new Date(date1.replace(/./g, ':')));
+    process.stdout.write(
+      `Using OSM data from ${osmDirectories[0]} \n`,
+    );
+    stream.push(createFile(router, 'streetGraph.obj', `${storageDir}/osm-builds/${osmDirectories[0]}/${router.id}/streetGraph.obj`));
+  } else {
+    throw new Error(`No OSM directories can be found exist!\n`)
+  }
+  
+  stream.end();
+
+  return stream;
+}
+
+
+module.exports = {
+  prepareRouterData,
+  prepareRouterDataForOnlyStreetGraphBuild,
+  prepareRouterDataForPrebuiltStreetGraphBuild,
 };

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -3,6 +3,7 @@ const Vinyl = require('vinyl');
 const fs = require('fs');
 const cloneable = require('cloneable-readable');
 const { dataDir, storageDir } = require('../config');
+const { dirNameToDate } = require('../util');
 const assert = require('assert');
 
 function createFile(config, fileName, sourcePath) {
@@ -143,7 +144,7 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
 
   const osmDirectories = getDirectories(`${storageDir}/osm-builds/${process.env.DOCKER_TAG}`);
   if (osmDirectories.length > 0) {
-    osmDirectories.sort((date1, date2) => new Date(date1.replace(/./g, ':')) - new Date(date2.replace(/./g, ':')));
+    osmDirectories.sort((date1, date2) => dirNameToDate(date2) - dirNameToDate(date1));
     const osmPath = `${storageDir}/osm-builds/${process.env.DOCKER_TAG}/${osmDirectories[0]}/${router.id}`;
     process.stdout.write(
       `Using OSM data from ${osmPath} \n`,

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -124,7 +124,7 @@ function getDirectories(path) {
 }
 
 /**
- * Make router data ready for the street only graph build in opentripplanner.
+ * Make router data ready for the graph build from prebuilt data in opentripplanner.
  * In the prebuilt build case, only gtfs data is fetched from the data directory,
  * osm and dem data, as well as the prebuilt streetGraph.obj file is fetched from the osm-builds directory.
  */

--- a/task/PrepareRouterData.js
+++ b/task/PrepareRouterData.js
@@ -148,15 +148,20 @@ function prepareRouterDataForPrebuiltStreetGraphBuild (router) {
     process.stdout.write(
       `Using OSM data from ${osmPath} \n`,
     );
-    // This is needed for gtfs data fitting.
+    // This is needed for gtfs data fitting and seeding.
     router.osm.forEach(osmId => {
       const name = osmId + '.pbf';
       stream.push(createFile(router, name, osmPath));
     });
+    // This is needed for seeding.
+    if (router.dem) {
+      const name = router.dem + '.tif';
+      stream.push(createFile(router, name, osmPath));
+    }
     // This is the prebuilt street graph.
     stream.push(createFile(router, 'streetGraph.obj', osmPath));
   } else {
-    throw new Error(`No OSM directories can be found exist!\n`)
+    throw new Error(`No OSM directories can be found!\n`)
   }
   
   stream.end();

--- a/task/Update.js
+++ b/task/Update.js
@@ -14,7 +14,7 @@ const { router } = require('../config');
 const assert = require('assert');
 
 const MAX_GTFS_FALLBACK = 2; // threshold for aborting data loading
-const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || '';
+const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || 'NO_SPLIT_BUILD';
 
 const start = promisify((task, cb) => gulp.series(task)(cb));
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -126,7 +126,7 @@ async function buildGraph(name) {
   await start('router:buildGraph');
 
   if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
-    process.stdout.write('Skipping all tests');
+    process.stdout.write('Skipping all tests\n');
   } else {
     process.stdout.write('Test the newly built graph with OTPQA\n');
     execFileSync('./test.sh', [], { stdio: [0, 1, 2] });
@@ -221,7 +221,7 @@ async function buildWithPrebuiltStreetGraph(name) {
   await start('router:buildWithPrebuiltStreetGraph');
 
   if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
-    process.stdout.write('Skipping all tests');
+    process.stdout.write('Skipping all tests\n');
   } else {
     process.stdout.write('Test the newly built graph with OTPQA\n');
     execFileSync('./test.sh', [], { stdio: [0, 1, 2] });

--- a/task/Update.js
+++ b/task/Update.js
@@ -14,8 +14,10 @@ const { router } = require('../config');
 const assert = require('assert');
 
 const MAX_GTFS_FALLBACK = 2; // threshold for aborting data loading
-const ONLY_BUILD_STREET_GRAPH = process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
-const USE_PREBUILT_STREET_GRAPH = process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const ONLY_BUILD_STREET_GRAPH =
+  process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const USE_PREBUILT_STREET_GRAPH =
+  process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
 
 const start = promisify((task, cb) => gulp.series(task)(cb));
 
@@ -26,11 +28,7 @@ const start = promisify((task, cb) => gulp.series(task)(cb));
  * @returns date as string
  */
 function getDateString() {
-  return new Date()
-    .toISOString()
-    .slice(0, -5)
-    .concat('Z')
-    .replace(/:/g, '.');
+  return new Date().toISOString().slice(0, -5).concat('Z').replace(/:/g, '.');
 }
 
 /**
@@ -81,7 +79,9 @@ async function buildStreetOnlyGraph(name) {
   await start('router:store');
 
   if (!process.env.NOCLEANUP) {
-    process.stdout.write('Remove oldest street only graph data versions from storage\n');
+    process.stdout.write(
+      'Remove oldest street only graph data versions from storage\n',
+    );
     await start('storage:cleanupStreetOnlyGraphData');
   }
 
@@ -90,7 +90,9 @@ async function buildStreetOnlyGraph(name) {
       `${name} street only graph data updated, but partially falling back to older data :boom:`,
     );
   } else {
-    updateSlackMessage(`${name} street only graph data updated :white_check_mark:`);
+    updateSlackMessage(
+      `${name} street only graph data updated :white_check_mark:`,
+    );
   }
 }
 
@@ -225,7 +227,7 @@ async function buildWithPrebuiltStreetGraph(name) {
     await start('seed');
     process.stdout.write('Seeded\n');
   }
-  
+
   await start('gtfs:update');
 
   process.stdout.write('Build routing graph from prebuilt street only graph\n');
@@ -307,7 +309,9 @@ async function buildWithPrebuiltStreetGraph(name) {
       `${name} data updated from prebuilt street only graph, but partially falling back to older data :boom:`,
     );
   } else {
-    updateSlackMessage(`${name} data updated from prebuilt street only graph :white_check_mark:`);
+    updateSlackMessage(
+      `${name} data updated from prebuilt street only graph :white_check_mark:`,
+    );
   }
 }
 
@@ -318,11 +322,11 @@ async function update() {
   const name = router.id;
   try {
     if (ONLY_BUILD_STREET_GRAPH) {
-      await buildStreetOnlyGraph(name)
+      await buildStreetOnlyGraph(name);
     } else if (USE_PREBUILT_STREET_GRAPH) {
-      await buildWithPrebuiltStreetGraph(name)
+      await buildWithPrebuiltStreetGraph(name);
     } else {
-      await buildGraph(name)
+      await buildGraph(name);
     }
   } catch (err) {
     postSlackMessage(`${name} data update failed: ` + err.message);

--- a/task/Update.js
+++ b/task/Update.js
@@ -10,11 +10,10 @@ const { execFileSync } = require('child_process');
 const fs = require('fs');
 const { postSlackMessage, updateSlackMessage } = require('../util');
 require('../gulpfile');
-const { router } = require('../config');
+const { router, SPLIT_BUILD_TYPE } = require('../config');
 const assert = require('assert');
 
 const MAX_GTFS_FALLBACK = 2; // threshold for aborting data loading
-const { SPLIT_BUILD_TYPE } = require('./config.js');
 
 const start = promisify((task, cb) => gulp.series(task)(cb));
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -228,7 +228,7 @@ async function buildWithPrebuiltStreetGraph(name) {
   
   await start('gtfs:update');
 
-  process.stdout.write('Build routing graph\n');
+  process.stdout.write('Build routing graph from prebuilt street only graph\n');
   await start('router:buildWithPrebuiltStreetGraph');
 
   if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
@@ -304,10 +304,10 @@ async function buildWithPrebuiltStreetGraph(name) {
 
   if (global.hasFailures) {
     updateSlackMessage(
-      `${name} data updated, but partially falling back to older data :boom:`,
+      `${name} data updated from prebuilt street only graph, but partially falling back to older data :boom:`,
     );
   } else {
-    updateSlackMessage(`${name} data updated :white_check_mark:`);
+    updateSlackMessage(`${name} data updated from prebuilt street only graph :white_check_mark:`);
   }
 }
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -79,8 +79,19 @@ async function buildOnlyStreetGraph(name) {
 
   process.stdout.write('Uploading street graph only build data to storage\n');
   await start('router:store');
-  
-  updateSlackMessage(`${name} street only graph data updated :white_check_mark:`);
+
+  if (!process.env.NOCLEANUP) {
+    process.stdout.write('Remove oldest only street graph data versions from storage\n');
+    await start('storage:cleanupOnlyStreetGraphData');
+  }
+
+  if (global.hasFailures) {
+    updateSlackMessage(
+      `${name} street only graph data updated, but partially falling back to older data :boom:`,
+    );
+  } else {
+    updateSlackMessage(`${name} street only graph data updated :white_check_mark:`);
+  }
 }
 
 /**

--- a/task/Update.js
+++ b/task/Update.js
@@ -75,10 +75,10 @@ async function buildOnlyStreetGraph(name) {
 
   const date = getDateString();
 
-  global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
+  global.storageDirName = `osm-builds/${process.env.DOCKER_TAG}/${date}/${name}`;
 
-  process.stdout.write('Uploading only street graph data to storage\n');
-  await start('router:storeOnlyStreetGraphData');
+  process.stdout.write('Uploading street graph only build data to storage\n');
+  await start('router:store');
   
   updateSlackMessage(`${name} street only graph data updated :white_check_mark:`);
 }

--- a/task/Update.js
+++ b/task/Update.js
@@ -28,16 +28,15 @@ function getDateString() {
   return new Date().toISOString().slice(0, -5).concat('Z').replace(/:/g, '.');
 }
 
-/**
- * This function only builds the street graph with OSM and DEM data.
- */
-async function buildStreetOnlyGraph(name) {
+async function handleSeeding() {
   if (!process.env.NOSEED) {
     process.stdout.write('Starting seeding\n');
     await start('seed');
     process.stdout.write('Seeded\n');
   }
+}
 
+async function handleOsmAndDemUpdate() {
   if (!process.env.NODEM) {
     // we track data rejections using this global variable
     global.hasFailures = false;
@@ -64,12 +63,85 @@ async function buildStreetOnlyGraph(name) {
     global.hasFailures = true;
     postSlackMessage('OSM data update failed, using previous version :boom:');
   }
+}
+
+function handleTests() {
+  if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
+    process.stdout.write('Skipping all tests\n');
+  } else {
+    process.stdout.write('Test the newly built graph with OTPQA\n');
+    execFileSync('./test.sh', [], { stdio: [0, 1, 2] });
+  }
+}
+
+async function handleGtfsFallback(logFile) {
+  // testing detected routing problems
+  global.hasFailures = true;
+
+  global.failedFeeds = fs.readFileSync(logFile, 'utf8'); // comma separated list of feed ids. No newline at end!
+  fs.unlinkSync(logFile); // cleanup for local use
+
+  if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
+    updateSlackMessage(
+      'Aborting the data update because too many quality tests failed :boom:',
+    );
+    process.exit(1);
+  }
+
+  postSlackMessage(
+    `GTFS packages ${global.failedFeeds} rejected, using fallback to current data`,
+  );
+  // use seed packages for failed feeds
+  await start('gtfs:fallback');
+}
+
+function buildAndDeployDockerImages(date) {
+  process.stdout.write('Build and deploy Docker images\n');
+  execFileSync('./otp-data-server/deploy.sh', [date], {
+    stdio: [0, 1, 2],
+    env: {
+      OTP_TAG: process.env.OTP_TAG,
+      OTP_GRAPH_DIR: global.storageDirName,
+      ROUTER_NAME: process.env.ROUTER_NAME,
+      ORG: process.env.ORG,
+      DOCKER_TAG: process.env.DOCKER_TAG,
+      DOCKER_USER: process.env.DOCKER_USER,
+      DOCKER_AUTH: process.env.DOCKER_AUTH,
+    },
+  });
+  execFileSync('./opentripplanner/deploy-otp.sh', [date], {
+    stdio: [0, 1, 2],
+    env: {
+      OTP_TAG: process.env.OTP_TAG,
+      OTP_GRAPH_DIR: global.storageDirName,
+      ROUTER_NAME: process.env.ROUTER_NAME,
+      ORG: process.env.ORG,
+      DOCKER_TAG: process.env.DOCKER_TAG,
+      DOCKER_USER: process.env.DOCKER_USER,
+      DOCKER_AUTH: process.env.DOCKER_AUTH,
+    },
+  });
+}
+
+async function handleCleanup() {
+  if (!process.env.NOCLEANUP) {
+    process.stdout.write('Remove oldest data versions from storage\n');
+    await start('storage:cleanup');
+  }
+}
+
+/**
+ * This function only builds the street graph with OSM and DEM data.
+ */
+async function buildStreetOnlyGraph(name) {
+  await handleSeeding()
+
+  await handleOsmAndDemUpdate()
 
   process.stdout.write('Build street only graph\n');
   await start('router:buildStreetOnlyGraph');
 
   const date = getDateString();
-
   global.storageDirName = `osm-builds/${process.env.DOCKER_TAG}/${date}/${name}`;
 
   process.stdout.write('Uploading street graph only build data to storage\n');
@@ -97,114 +169,34 @@ async function buildStreetOnlyGraph(name) {
  * This function does the whole build.
  */
 async function buildGraph(name) {
-  if (!process.env.NOSEED) {
-    process.stdout.write('Starting seeding\n');
-    await start('seed');
-    process.stdout.write('Seeded\n');
-  }
+  await handleSeeding()
 
-  if (!process.env.NODEM) {
-    // we track data rejections using this global variable
-    global.hasFailures = false;
-    await start('dem:update');
-    if (global.hasFailures) {
-      postSlackMessage('DEM update failed, using previous version :boom:');
-    }
-  }
-
-  // OSM update is more complicated. Download often fails, so there is a retry loop,
-  // which breaks when a big enough file gets loaded
-  global.blobSizeOk = false; // ugly hack but gulp does not return any values from tasks
-  for (let i = 0; i < 3; i++) {
-    await start('osm:update');
-    if (global.blobSizeOk) {
-      break;
-    }
-    if (i < 2) {
-      // sleep 10 mins before next attempt
-      await new Promise(resolve => setTimeout(resolve, 600000));
-    }
-  }
-  if (!global.blobSizeOk) {
-    global.hasFailures = true;
-    postSlackMessage('OSM data update failed, using previous version :boom:');
-  }
+  await handleOsmAndDemUpdate()
 
   await start('gtfs:update');
 
   process.stdout.write('Build routing graph\n');
   await start('router:buildGraph');
 
-  if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
-    process.stdout.write('Skipping all tests\n');
-  } else {
-    process.stdout.write('Test the newly built graph with OTPQA\n');
-    execFileSync('./test.sh', [], { stdio: [0, 1, 2] });
-  }
+  handleTests()
 
   const logFile = 'failed_feeds.txt';
   if (fs.existsSync(logFile)) {
-    // testing detected routing problems
-    global.hasFailures = true;
-
-    global.failedFeeds = fs.readFileSync(logFile, 'utf8'); // comma separated list of feed ids. No newline at end!
-    fs.unlinkSync(logFile); // cleanup for local use
-
-    if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
-      updateSlackMessage(
-        'Aborting the data update because too many quality tests failed :boom:',
-      );
-      process.exit(1);
-    }
-
-    postSlackMessage(
-      `GTFS packages ${global.failedFeeds} rejected, using fallback to current data`,
-    );
-    // use seed packages for failed feeds
-    await start('gtfs:fallback');
-
+    await handleGtfsFallback(logFile)
     // rebuild the graph
     process.stdout.write('Rebuild graph using fallback data\n');
     await start('router:buildGraph');
   }
 
   const date = getDateString();
-
   global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
 
   process.stdout.write('Uploading data to storage\n');
   await start('router:store');
 
-  process.stdout.write('Build and deploy Docker images\n');
-  execFileSync('./otp-data-server/deploy.sh', [date], {
-    stdio: [0, 1, 2],
-    env: {
-      OTP_TAG: process.env.OTP_TAG,
-      OTP_GRAPH_DIR: global.storageDirName,
-      ROUTER_NAME: process.env.ROUTER_NAME,
-      ORG: process.env.ORG,
-      DOCKER_TAG: process.env.DOCKER_TAG,
-      DOCKER_USER: process.env.DOCKER_USER,
-      DOCKER_AUTH: process.env.DOCKER_AUTH,
-    },
-  });
-  execFileSync('./opentripplanner/deploy-otp.sh', [date], {
-    stdio: [0, 1, 2],
-    env: {
-      OTP_TAG: process.env.OTP_TAG,
-      OTP_GRAPH_DIR: global.storageDirName,
-      ROUTER_NAME: process.env.ROUTER_NAME,
-      ORG: process.env.ORG,
-      DOCKER_TAG: process.env.DOCKER_TAG,
-      DOCKER_USER: process.env.DOCKER_USER,
-      DOCKER_AUTH: process.env.DOCKER_AUTH,
-    },
-  });
+  buildAndDeployDockerImages(date)
 
-  if (!process.env.NOCLEANUP) {
-    process.stdout.write('Remove oldest data versions from storage\n');
-    await start('storage:cleanup');
-  }
+  await handleCleanup()
 
   if (global.hasFailures) {
     updateSlackMessage(
@@ -219,87 +211,32 @@ async function buildGraph(name) {
  * This function builds the graph from prebuilt street graph data.
  */
 async function buildWithPrebuiltStreetGraph(name) {
-  if (!process.env.NOSEED) {
-    process.stdout.write('Starting seeding\n');
-    await start('seed');
-    process.stdout.write('Seeded\n');
-  }
+  await handleSeeding()
 
   await start('gtfs:update');
 
   process.stdout.write('Build routing graph from prebuilt street only graph\n');
   await start('router:buildWithPrebuiltStreetGraph');
 
-  if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
-    process.stdout.write('Skipping all tests\n');
-  } else {
-    process.stdout.write('Test the newly built graph with OTPQA\n');
-    execFileSync('./test.sh', [], { stdio: [0, 1, 2] });
-  }
+  handleTests()
 
   const logFile = 'failed_feeds.txt';
   if (fs.existsSync(logFile)) {
-    // testing detected routing problems
-    global.hasFailures = true;
-
-    global.failedFeeds = fs.readFileSync(logFile, 'utf8'); // comma separated list of feed ids. No newline at end!
-    fs.unlinkSync(logFile); // cleanup for local use
-
-    if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
-      updateSlackMessage(
-        'Aborting the data update because too many quality tests failed :boom:',
-      );
-      process.exit(1);
-    }
-
-    postSlackMessage(
-      `GTFS packages ${global.failedFeeds} rejected, using fallback to current data`,
-    );
-    // use seed packages for failed feeds
-    await start('gtfs:fallback');
-
+    await handleGtfsFallback(logFile)
     // rebuild the graph
     process.stdout.write('Rebuild graph using fallback data\n');
     await start('router:buildWithPrebuiltStreetGraph');
   }
 
   const date = getDateString();
-
   global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
 
   process.stdout.write('Uploading data to storage\n');
   await start('router:storeForPrebuiltStreetGraphDataBuild');
 
-  process.stdout.write('Build and deploy Docker images\n');
-  execFileSync('./otp-data-server/deploy.sh', [date], {
-    stdio: [0, 1, 2],
-    env: {
-      OTP_TAG: process.env.OTP_TAG,
-      OTP_GRAPH_DIR: global.storageDirName,
-      ROUTER_NAME: process.env.ROUTER_NAME,
-      ORG: process.env.ORG,
-      DOCKER_TAG: process.env.DOCKER_TAG,
-      DOCKER_USER: process.env.DOCKER_USER,
-      DOCKER_AUTH: process.env.DOCKER_AUTH,
-    },
-  });
-  execFileSync('./opentripplanner/deploy-otp.sh', [date], {
-    stdio: [0, 1, 2],
-    env: {
-      OTP_TAG: process.env.OTP_TAG,
-      OTP_GRAPH_DIR: global.storageDirName,
-      ROUTER_NAME: process.env.ROUTER_NAME,
-      ORG: process.env.ORG,
-      DOCKER_TAG: process.env.DOCKER_TAG,
-      DOCKER_USER: process.env.DOCKER_USER,
-      DOCKER_AUTH: process.env.DOCKER_AUTH,
-    },
-  });
+  buildAndDeployDockerImages(date)
 
-  if (!process.env.NOCLEANUP) {
-    process.stdout.write('Remove oldest data versions from storage\n');
-    await start('storage:cleanup');
-  }
+  await handleCleanup()
 
   if (global.hasFailures) {
     updateSlackMessage(

--- a/task/Update.js
+++ b/task/Update.js
@@ -14,7 +14,7 @@ const { router } = require('../config');
 const assert = require('assert');
 
 const MAX_GTFS_FALLBACK = 2; // threshold for aborting data loading
-const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || 'NO_SPLIT_BUILD';
+const { SPLIT_BUILD_TYPE } = require('./config.js');
 
 const start = promisify((task, cb) => gulp.series(task)(cb));
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -14,10 +14,7 @@ const { router } = require('../config');
 const assert = require('assert');
 
 const MAX_GTFS_FALLBACK = 2; // threshold for aborting data loading
-const ONLY_BUILD_STREET_GRAPH =
-  process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
-const USE_PREBUILT_STREET_GRAPH =
-  process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const SPLIT_BUILD_TYPE = process.env.SPLIT_BUILD_TYPE || '';
 
 const start = promisify((task, cb) => gulp.series(task)(cb));
 
@@ -321,12 +318,16 @@ async function update() {
 
   const name = router.id;
   try {
-    if (ONLY_BUILD_STREET_GRAPH) {
-      await buildStreetOnlyGraph(name);
-    } else if (USE_PREBUILT_STREET_GRAPH) {
-      await buildWithPrebuiltStreetGraph(name);
-    } else {
-      await buildGraph(name);
+    switch (SPLIT_BUILD_TYPE) {
+      case 'ONLY_BUILD_STREET_GRAPH':
+        await buildStreetOnlyGraph(name);
+        break;
+      case 'USE_PREBUILT_STREET_GRAPH':
+        await buildWithPrebuiltStreetGraph(name);
+        break;
+      default:
+        await buildGraph(name);
+        break;
     }
   } catch (err) {
     postSlackMessage(`${name} data update failed: ` + err.message);

--- a/task/Update.js
+++ b/task/Update.js
@@ -268,7 +268,7 @@ async function buildWithPrebuiltStreetGraph(name) {
   global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
 
   process.stdout.write('Uploading data to storage\n');
-  await start('router:store');
+  await start('router:storeForPrebuiltStreetGraphDataBuild');
 
   process.stdout.write('Build and deploy Docker images\n');
   execFileSync('./otp-data-server/deploy.sh', [date], {

--- a/task/Update.js
+++ b/task/Update.js
@@ -36,7 +36,7 @@ function getDateString() {
 /**
  * This function only builds the street graph with OSM and DEM data.
  */
-async function buildOnlyStreetGraph(name) {
+async function buildStreetOnlyGraph(name) {
   if (!process.env.NOSEED) {
     process.stdout.write('Starting seeding\n');
     await start('seed');
@@ -70,8 +70,8 @@ async function buildOnlyStreetGraph(name) {
     postSlackMessage('OSM data update failed, using previous version :boom:');
   }
 
-  process.stdout.write('Build only street graph\n');
-  await start('router:buildOnlyStreetGraph');
+  process.stdout.write('Build street only graph\n');
+  await start('router:buildStreetOnlyGraph');
 
   const date = getDateString();
 
@@ -81,8 +81,8 @@ async function buildOnlyStreetGraph(name) {
   await start('router:store');
 
   if (!process.env.NOCLEANUP) {
-    process.stdout.write('Remove oldest only street graph data versions from storage\n');
-    await start('storage:cleanupOnlyStreetGraphData');
+    process.stdout.write('Remove oldest street only graph data versions from storage\n');
+    await start('storage:cleanupStreetOnlyGraphData');
   }
 
   if (global.hasFailures) {
@@ -318,7 +318,7 @@ async function update() {
   const name = router.id;
   try {
     if (ONLY_BUILD_STREET_GRAPH) {
-      await buildOnlyStreetGraph(name)
+      await buildStreetOnlyGraph(name)
     } else if (USE_PREBUILT_STREET_GRAPH) {
       await buildWithPrebuiltStreetGraph(name)
     } else {

--- a/task/Update.js
+++ b/task/Update.js
@@ -134,9 +134,9 @@ async function handleCleanup() {
  * This function only builds the street graph with OSM and DEM data.
  */
 async function buildStreetOnlyGraph(name) {
-  await handleSeeding()
+  await handleSeeding();
 
-  await handleOsmAndDemUpdate()
+  await handleOsmAndDemUpdate();
 
   process.stdout.write('Build street only graph\n');
   await start('router:buildStreetOnlyGraph');
@@ -169,20 +169,20 @@ async function buildStreetOnlyGraph(name) {
  * This function does the whole build.
  */
 async function buildGraph(name) {
-  await handleSeeding()
+  await handleSeeding();
 
-  await handleOsmAndDemUpdate()
+  await handleOsmAndDemUpdate();
 
   await start('gtfs:update');
 
   process.stdout.write('Build routing graph\n');
   await start('router:buildGraph');
 
-  handleTests()
+  handleTests();
 
   const logFile = 'failed_feeds.txt';
   if (fs.existsSync(logFile)) {
-    await handleGtfsFallback(logFile)
+    await handleGtfsFallback(logFile);
     // rebuild the graph
     process.stdout.write('Rebuild graph using fallback data\n');
     await start('router:buildGraph');
@@ -194,9 +194,9 @@ async function buildGraph(name) {
   process.stdout.write('Uploading data to storage\n');
   await start('router:store');
 
-  buildAndDeployDockerImages(date)
+  buildAndDeployDockerImages(date);
 
-  await handleCleanup()
+  await handleCleanup();
 
   if (global.hasFailures) {
     updateSlackMessage(
@@ -211,18 +211,18 @@ async function buildGraph(name) {
  * This function builds the graph from prebuilt street graph data.
  */
 async function buildWithPrebuiltStreetGraph(name) {
-  await handleSeeding()
+  await handleSeeding();
 
   await start('gtfs:update');
 
   process.stdout.write('Build routing graph from prebuilt street only graph\n');
   await start('router:buildWithPrebuiltStreetGraph');
 
-  handleTests()
+  handleTests();
 
   const logFile = 'failed_feeds.txt';
   if (fs.existsSync(logFile)) {
-    await handleGtfsFallback(logFile)
+    await handleGtfsFallback(logFile);
     // rebuild the graph
     process.stdout.write('Rebuild graph using fallback data\n');
     await start('router:buildWithPrebuiltStreetGraph');
@@ -234,9 +234,9 @@ async function buildWithPrebuiltStreetGraph(name) {
   process.stdout.write('Uploading data to storage\n');
   await start('router:storeForPrebuiltStreetGraphDataBuild');
 
-  buildAndDeployDockerImages(date)
+  buildAndDeployDockerImages(date);
 
-  await handleCleanup()
+  await handleCleanup();
 
   if (global.hasFailures) {
     updateSlackMessage(

--- a/task/Update.js
+++ b/task/Update.js
@@ -14,13 +14,29 @@ const { router } = require('../config');
 const assert = require('assert');
 
 const MAX_GTFS_FALLBACK = 2; // threshold for aborting data loading
+const ONLY_BUILD_STREET_GRAPH = process.env.ONLY_BUILD_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
+const USE_PREBUILT_STREET_GRAPH = process.env.USE_PREBUILT_STREET_GRAPH?.toLowerCase?.() === 'true' || false;
 
 const start = promisify((task, cb) => gulp.series(task)(cb));
 
-async function update() {
-  // check environmental variables which needs to be defined
-  assert(process.env.DOCKER_TAG !== undefined, 'DOCKER_TAG must be defined');
+/**
+ * Docker tags don't work with ':' and file names are also prettier without them. We also need to
+ * remove milliseconds because they are not relevant and make converting string back to ISO format
+ * more difficult.
+ * @returns date as string
+ */
+function getDateString() {
+  return new Date()
+    .toISOString()
+    .slice(0, -5)
+    .concat('Z')
+    .replace(/:/g, '.');
+}
 
+/**
+ * This function only builds the street graph with OSM and DEM data.
+ */
+async function buildOnlyStreetGraph(name) {
   if (!process.env.NOSEED) {
     process.stdout.write('Starting seeding\n');
     await start('seed');
@@ -37,7 +53,7 @@ async function update() {
   }
 
   // OSM update is more complicated. Download often fails, so there is a retry loop,
-  //  which breaks when a big enough file gets loaded
+  // which breaks when a big enough file gets loaded
   global.blobSizeOk = false; // ugly hack but gulp does not return any values from tasks
   for (let i = 0; i < 3; i++) {
     await start('osm:update');
@@ -54,97 +70,248 @@ async function update() {
     postSlackMessage('OSM data update failed, using previous version :boom:');
   }
 
+  process.stdout.write('Build only street graph\n');
+  await start('router:buildOnlyStreetGraph');
+
+  const date = getDateString();
+
+  global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
+
+  process.stdout.write('Uploading only street graph data to storage\n');
+  await start('router:storeOnlyStreetGraphData');
+  
+  updateSlackMessage(`${name} street only graph data updated :white_check_mark:`);
+}
+
+/**
+ * This function does the whole build.
+ */
+async function buildGraph(name) {
+  if (!process.env.NOSEED) {
+    process.stdout.write('Starting seeding\n');
+    await start('seed');
+    process.stdout.write('Seeded\n');
+  }
+
+  if (!process.env.NODEM) {
+    // we track data rejections using this global variable
+    global.hasFailures = false;
+    await start('dem:update');
+    if (global.hasFailures) {
+      postSlackMessage('DEM update failed, using previous version :boom:');
+    }
+  }
+
+  // OSM update is more complicated. Download often fails, so there is a retry loop,
+  // which breaks when a big enough file gets loaded
+  global.blobSizeOk = false; // ugly hack but gulp does not return any values from tasks
+  for (let i = 0; i < 3; i++) {
+    await start('osm:update');
+    if (global.blobSizeOk) {
+      break;
+    }
+    if (i < 2) {
+      // sleep 10 mins before next attempt
+      await new Promise(resolve => setTimeout(resolve, 600000));
+    }
+  }
+  if (!global.blobSizeOk) {
+    global.hasFailures = true;
+    postSlackMessage('OSM data update failed, using previous version :boom:');
+  }
+
+  await start('gtfs:update');
+
+  process.stdout.write('Build routing graph\n');
+  await start('router:buildGraph');
+
+  if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
+    process.stdout.write('Skipping all tests');
+  } else {
+    process.stdout.write('Test the newly built graph with OTPQA\n');
+    execFileSync('./test.sh', [], { stdio: [0, 1, 2] });
+  }
+
+  const logFile = 'failed_feeds.txt';
+  if (fs.existsSync(logFile)) {
+    // testing detected routing problems
+    global.hasFailures = true;
+
+    global.failedFeeds = fs.readFileSync(logFile, 'utf8'); // comma separated list of feed ids. No newline at end!
+    fs.unlinkSync(logFile); // cleanup for local use
+
+    if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
+      updateSlackMessage(
+        'Aborting the data update because too many quality tests failed :boom:',
+      );
+      process.exit(1);
+    }
+
+    postSlackMessage(
+      `GTFS packages ${global.failedFeeds} rejected, using fallback to current data`,
+    );
+    // use seed packages for failed feeds
+    await start('gtfs:fallback');
+
+    // rebuild the graph
+    process.stdout.write('Rebuild graph using fallback data\n');
+    await start('router:buildGraph');
+  }
+
+  const date = getDateString();
+
+  global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
+
+  process.stdout.write('Uploading data to storage\n');
+  await start('router:store');
+
+  process.stdout.write('Build and deploy Docker images\n');
+  execFileSync('./otp-data-server/deploy.sh', [date], {
+    stdio: [0, 1, 2],
+    env: {
+      OTP_TAG: process.env.OTP_TAG,
+      OTP_GRAPH_DIR: global.storageDirName,
+      ROUTER_NAME: process.env.ROUTER_NAME,
+      ORG: process.env.ORG,
+      DOCKER_TAG: process.env.DOCKER_TAG,
+      DOCKER_USER: process.env.DOCKER_USER,
+      DOCKER_AUTH: process.env.DOCKER_AUTH,
+    },
+  });
+  execFileSync('./opentripplanner/deploy-otp.sh', [date], {
+    stdio: [0, 1, 2],
+    env: {
+      OTP_TAG: process.env.OTP_TAG,
+      OTP_GRAPH_DIR: global.storageDirName,
+      ROUTER_NAME: process.env.ROUTER_NAME,
+      ORG: process.env.ORG,
+      DOCKER_TAG: process.env.DOCKER_TAG,
+      DOCKER_USER: process.env.DOCKER_USER,
+      DOCKER_AUTH: process.env.DOCKER_AUTH,
+    },
+  });
+
+  if (!process.env.NOCLEANUP) {
+    process.stdout.write('Remove oldest data versions from storage\n');
+    await start('storage:cleanup');
+  }
+
+  if (global.hasFailures) {
+    updateSlackMessage(
+      `${name} data updated, but partially falling back to older data :boom:`,
+    );
+  } else {
+    updateSlackMessage(`${name} data updated :white_check_mark:`);
+  }
+}
+
+/**
+ * This function builds the graph from prebuilt street graph data.
+ */
+async function buildWithPrebuiltStreetGraph(name) {
+  if (!process.env.NOSEED) {
+    process.stdout.write('Starting seeding\n');
+    await start('seed');
+    process.stdout.write('Seeded\n');
+  }
+  
+  await start('gtfs:update');
+
+  process.stdout.write('Build routing graph\n');
+  await start('router:buildWithPrebuiltStreetGraph');
+
+  if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
+    process.stdout.write('Skipping all tests');
+  } else {
+    process.stdout.write('Test the newly built graph with OTPQA\n');
+    execFileSync('./test.sh', [], { stdio: [0, 1, 2] });
+  }
+
+  const logFile = 'failed_feeds.txt';
+  if (fs.existsSync(logFile)) {
+    // testing detected routing problems
+    global.hasFailures = true;
+
+    global.failedFeeds = fs.readFileSync(logFile, 'utf8'); // comma separated list of feed ids. No newline at end!
+    fs.unlinkSync(logFile); // cleanup for local use
+
+    if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
+      updateSlackMessage(
+        'Aborting the data update because too many quality tests failed :boom:',
+      );
+      process.exit(1);
+    }
+
+    postSlackMessage(
+      `GTFS packages ${global.failedFeeds} rejected, using fallback to current data`,
+    );
+    // use seed packages for failed feeds
+    await start('gtfs:fallback');
+
+    // rebuild the graph
+    process.stdout.write('Rebuild graph using fallback data\n');
+    await start('router:buildWithPrebuiltStreetGraph');
+  }
+
+  const date = getDateString();
+
+  global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
+
+  process.stdout.write('Uploading data to storage\n');
+  await start('router:store');
+
+  process.stdout.write('Build and deploy Docker images\n');
+  execFileSync('./otp-data-server/deploy.sh', [date], {
+    stdio: [0, 1, 2],
+    env: {
+      OTP_TAG: process.env.OTP_TAG,
+      OTP_GRAPH_DIR: global.storageDirName,
+      ROUTER_NAME: process.env.ROUTER_NAME,
+      ORG: process.env.ORG,
+      DOCKER_TAG: process.env.DOCKER_TAG,
+      DOCKER_USER: process.env.DOCKER_USER,
+      DOCKER_AUTH: process.env.DOCKER_AUTH,
+    },
+  });
+  execFileSync('./opentripplanner/deploy-otp.sh', [date], {
+    stdio: [0, 1, 2],
+    env: {
+      OTP_TAG: process.env.OTP_TAG,
+      OTP_GRAPH_DIR: global.storageDirName,
+      ROUTER_NAME: process.env.ROUTER_NAME,
+      ORG: process.env.ORG,
+      DOCKER_TAG: process.env.DOCKER_TAG,
+      DOCKER_USER: process.env.DOCKER_USER,
+      DOCKER_AUTH: process.env.DOCKER_AUTH,
+    },
+  });
+
+  if (!process.env.NOCLEANUP) {
+    process.stdout.write('Remove oldest data versions from storage\n');
+    await start('storage:cleanup');
+  }
+
+  if (global.hasFailures) {
+    updateSlackMessage(
+      `${name} data updated, but partially falling back to older data :boom:`,
+    );
+  } else {
+    updateSlackMessage(`${name} data updated :white_check_mark:`);
+  }
+}
+
+async function update() {
+  // check environmental variables which needs to be defined
+  assert(process.env.DOCKER_TAG !== undefined, 'DOCKER_TAG must be defined');
+
   const name = router.id;
   try {
-    await start('gtfs:update');
-
-    process.stdout.write('Build routing graph\n');
-    await start('router:buildGraph');
-
-    if (process.env.SKIPPED_SITES === 'all' || process.env.SKIP_OTP_TESTS) {
-      process.stdout.write('Skipping all tests');
+    if (ONLY_BUILD_STREET_GRAPH) {
+      await buildOnlyStreetGraph(name)
+    } else if (USE_PREBUILT_STREET_GRAPH) {
+      await buildWithPrebuiltStreetGraph(name)
     } else {
-      process.stdout.write('Test the newly built graph with OTPQA\n');
-      execFileSync('./test.sh', [], { stdio: [0, 1, 2] });
-    }
-
-    const logFile = 'failed_feeds.txt';
-    if (fs.existsSync(logFile)) {
-      // testing detected routing problems
-      global.hasFailures = true;
-
-      global.failedFeeds = fs.readFileSync(logFile, 'utf8'); // comma separated list of feed ids. No newline at end!
-      fs.unlinkSync(logFile); // cleanup for local use
-
-      if (global.failedFeeds.split(',').length > MAX_GTFS_FALLBACK) {
-        updateSlackMessage(
-          'Aborting the data update because too many quality tests failed :boom:',
-        );
-        process.exit(1);
-      }
-
-      postSlackMessage(
-        `GTFS packages ${global.failedFeeds} rejected, using fallback to current data`,
-      );
-      // use seed packages for failed feeds
-      await start('gtfs:fallback');
-
-      // rebuild the graph
-      process.stdout.write('Rebuild graph using fallback data\n');
-      await start('router:buildGraph');
-    }
-
-    // Docker tags don't work with ':' and file names are also prettier without them. We also need to
-    // remove milliseconds because they are not relevant and make converting string back to ISO format
-    // more difficult.
-    const date = new Date()
-      .toISOString()
-      .slice(0, -5)
-      .concat('Z')
-      .replace(/:/g, '.');
-
-    global.storageDirName = `${process.env.DOCKER_TAG}/${date}/${name}`;
-
-    process.stdout.write('Uploading data to storage\n');
-    await start('router:store');
-
-    process.stdout.write('Build and deploy Docker images\n');
-    execFileSync('./otp-data-server/deploy.sh', [date], {
-      stdio: [0, 1, 2],
-      env: {
-        OTP_TAG: process.env.OTP_TAG,
-        OTP_GRAPH_DIR: global.storageDirName,
-        ROUTER_NAME: process.env.ROUTER_NAME,
-        ORG: process.env.ORG,
-        DOCKER_TAG: process.env.DOCKER_TAG,
-        DOCKER_USER: process.env.DOCKER_USER,
-        DOCKER_AUTH: process.env.DOCKER_AUTH,
-      },
-    });
-    execFileSync('./opentripplanner/deploy-otp.sh', [date], {
-      stdio: [0, 1, 2],
-      env: {
-        OTP_TAG: process.env.OTP_TAG,
-        OTP_GRAPH_DIR: global.storageDirName,
-        ROUTER_NAME: process.env.ROUTER_NAME,
-        ORG: process.env.ORG,
-        DOCKER_TAG: process.env.DOCKER_TAG,
-        DOCKER_USER: process.env.DOCKER_USER,
-        DOCKER_AUTH: process.env.DOCKER_AUTH,
-      },
-    });
-
-    if (!process.env.NOCLEANUP) {
-      process.stdout.write('Remove oldest data versions from storage\n');
-      await start('storage:cleanup');
-    }
-
-    if (global.hasFailures) {
-      updateSlackMessage(
-        `${name} data updated, but partially falling back to older data :boom:`,
-      );
-    } else {
-      updateSlackMessage(`${name} data updated :white_check_mark:`);
+      await buildGraph(name)
     }
   } catch (err) {
     postSlackMessage(`${name} data update failed: ` + err.message);


### PR DESCRIPTION
This PR splits the graph build into a street only graph build and a build that utilizes the prebuilt street only graph data.

Notes:
- This has been tested in the dev cluster
- The street only graph build output is located in `osm-builds/v3/...`
- The cleanup of the old files uses the same functionality as the normal builds
- The `ONLY_BUILD_STREET_GRAPH ` and `USE_PREBUILT_STREET_GRAPH` env variables are used to configure the new builds