### PR TITLE
Waltti test data updates

### DIFF
--- a/waltti-alt/config.js
+++ b/waltti-alt/config.js
@@ -9,16 +9,10 @@ module.exports = {
       true,
     ),
     mapSrc('TurkuTrunkroutes', 'http://data-test.foli.fi/gtfs/gtfs.zip', true),
-    mapSrc(
-      'Lahti',
-      'https://www.lsl.fi/tiedostot/testidata',
-      true,
-      undefined,
-      {
-        'fare_attributes.txt': 'digitransit_fare_attributes.txt',
-        'fare_rules.txt': 'digitransit_fare_rules.txt',
-      },
-    ),
+    mapSrc('Lahti', 'https://www.lsl.fi/tiedostot/testidata', true, undefined, {
+      'fare_attributes.txt': 'digitransit_fare_attributes.txt',
+      'fare_rules.txt': 'digitransit_fare_rules.txt',
+    }),
     mapSrc(
       'tampere',
       'https://ekstrat.tampere.fi/ekstrat/ptdata/tamperefeed_mattersoft.zip',

--- a/waltti-alt/config.js
+++ b/waltti-alt/config.js
@@ -10,18 +10,8 @@ module.exports = {
     ),
     mapSrc('TurkuTrunkroutes', 'http://data-test.foli.fi/gtfs/gtfs.zip', true),
     mapSrc(
-      'OULU',
-      'https://tvv.fra1.digitaloceanspaces.com/229.zip',
-      true,
-      undefined,
-      {
-        'fare_attributes.txt': 'digitransit_fare_attributes.txt',
-        'fare_rules.txt': 'digitransit_fare_rules.txt',
-      },
-    ),
-    mapSrc(
-      'Pori',
-      'https://tvv.fra1.digitaloceanspaces.com/231.zip',
+      'Lahti',
+      'https://www.lsl.fi/tiedostot/testidata',
       true,
       undefined,
       {

--- a/waltti-alt/config.js
+++ b/waltti-alt/config.js
@@ -19,6 +19,10 @@ module.exports = {
         'fare_rules.txt': 'digitransit_fare_rules.txt',
       },
     ),
+    mapSrc(
+      'tampere',
+      'https://ekstrat.tampere.fi/ekstrat/ptdata/tamperefeed_mattersoft.zip',
+    ),
   ],
   osm: ['oulu', 'southFinland'],
 };

--- a/waltti-alt/router-config.json
+++ b/waltti-alt/router-config.json
@@ -274,6 +274,23 @@
       "url": "http://digitransit-proxy:8080/out/lmj.mattersoft.fi/api/gtfsrealtime/v1.0/feed/servicealert",
       "feedId": "WalttiTest",
       "fuzzyTripMatching": false
+    },
+    {
+      "id": "tampere-trip-updates",
+      "type": "stop-time-updater",
+      "frequency": "60s",
+      "url": "http://digitransit-proxy:8080/out/nysse.mattersoft.fi/api/gtfsrealtime/v1.0/feed/tripupdate",
+      "feedId": "tampere",
+      "fuzzyTripMatching": false,
+      "backwardsDelayPropagationType": "ALWAYS"
+    },
+    {
+      "id": "tampere-alerts",
+      "type": "real-time-alerts",
+      "frequency": "30s",
+      "url": "http://digitransit-proxy:8080/out/nysse.mattersoft.fi/api/gtfsrealtime/v1.0/feed/servicealert",
+      "feedId": "tampere",
+      "fuzzyTripMatching": false
     }
   ]
 }

--- a/waltti-alt/router-config.json
+++ b/waltti-alt/router-config.json
@@ -257,6 +257,23 @@
       "url": "http://digitransit-proxy:8080/out/oulu.mattersoft.fi/api/gtfsrealtime/v1.0/feed/servicealert",
       "feedId": "OULU",
       "fuzzyTripMatching": false
+    },
+    {
+      "id": "walttitest-trip-updates",
+      "type": "stop-time-updater",
+      "frequency": "60s",
+      "url": "http://digitransit-proxy:8080/out/lmj.mattersoft.fi/api/gtfsrealtime/v1.0/feed/tripupdate",
+      "feedId": "WalttiTest",
+      "fuzzyTripMatching": false,
+      "backwardsDelayPropagationType": "ALWAYS"
+    },
+    {
+      "id": "walttitest-alerts",
+      "type": "real-time-alerts",
+      "frequency": "30s",
+      "url": "http://digitransit-proxy:8080/out/lmj.mattersoft.fi/api/gtfsrealtime/v1.0/feed/servicealert",
+      "feedId": "WalttiTest",
+      "fuzzyTripMatching": false
     }
   ]
 }


### PR DESCRIPTION
- Pori & Oulu data only in waltti (removed from waltti-alt)
- WalttiTest updaters in waltti-alt (moved from kube)
- Lahti test data added to waltti-alt
- Tampere test data added to waltti-alt (removed from kube)