### PR TITLE
Don't buffer zip reads/writes in memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker:dind
 MAINTAINER Digitransit version: 1
 
-RUN apk add --update --no-cache bash curl nodejs yarn && rm -rf /var/cache/apk/*
+RUN apk add --update --no-cache bash zip curl nodejs yarn && rm -rf /var/cache/apk/*
 
 WORKDIR /opt/otp-data-builder
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,7 @@ gulp.task(
     'osm:download',
     () =>
       gulp
-        .src(`${osmDlDir}/*`)
+        .src(`${osmDlDir}/*`, { buffer: false })
         .pipe(validateBlobSize())
         .pipe(testOTPFile())
         .pipe(gulp.dest(osmDir)),
@@ -105,7 +105,7 @@ gulp.task(
     },
     () =>
       gulp
-        .src(`${tmpDir}/*`)
+        .src(`${tmpDir}/*`, { buffer: false })
         .pipe(renameGTFSFile())
         .pipe(replaceGTFSFilesTask(config.gtfsMap))
         .pipe(gulp.dest(gtfsDlDir))
@@ -117,7 +117,10 @@ gulp.task(
 
 // Add feedId to gtfs files in id dir, and moves files to directory 'ready'
 gulp.task('gtfs:id', () =>
-  gulp.src(`${idDir}/*`).pipe(setFeedIdTask()).pipe(gulp.dest(gtfsDir)),
+  gulp
+    .src(`${idDir}/*`, { buffer: false })
+    .pipe(setFeedIdTask())
+    .pipe(gulp.dest(gtfsDir)),
 );
 
 // Runs mapFit on gtfs files if fit is enabled, or just moves files to directory 'filter'
@@ -129,7 +132,7 @@ gulp.task(
         () => prepareFit(config),
         () =>
           gulp
-            .src(`${fitDir}/*`)
+            .src(`${fitDir}/*`, { buffer: false })
             .pipe(extractFromZip(['stops.txt']))
             .pipe(mapFit(config)) // modify backup of stops.txt
             .pipe(addToZip(['stops.txt']))
@@ -141,7 +144,7 @@ gulp.task(
 
 gulp.task('copyRules', () =>
   gulp
-    .src(`${config.router.id}/gtfs-rules/*`)
+    .src(`${config.router.id}/gtfs-rules/*`, { buffer: false })
     .pipe(gulp.dest(`${config.dataDir}/${config.router.id}/gtfs-rules`)),
 );
 
@@ -152,7 +155,7 @@ gulp.task(
     'copyRules',
     () =>
       gulp
-        .src(`${filterDir}/*.zip`)
+        .src(`${filterDir}/*.zip`, { buffer: false })
         .pipe(extractFromZip(config.passOBAfilter))
         .pipe(OBAFilterTask(config.gtfsMap))
         .pipe(addToZip(config.passOBAfilter))
@@ -171,7 +174,7 @@ gulp.task('gtfs:fallback', () => {
   const sources = global.failedFeeds
     .split(',')
     .map(feed => `${gtfsSeedDir}/${feed}-gtfs.zip`);
-  return gulp.src(sources).pipe(gulp.dest(gtfsDir));
+  return gulp.src(sources, { buffer: false }).pipe(gulp.dest(gtfsDir));
 });
 
 gulp.task('gtfs:del', () => del([gtfsSeedDir, gtfsDir]));
@@ -180,7 +183,7 @@ gulp.task(
   'gtfs:seed',
   gulp.series('gtfs:del', () =>
     gulp
-      .src(`${seedSourceDir}/*-gtfs.zip`)
+      .src(`${seedSourceDir}/*-gtfs.zip`, { buffer: false })
       .pipe(gulp.dest(gtfsSeedDir))
       .pipe(gulp.dest(gtfsDir)),
   ),
@@ -191,7 +194,9 @@ gulp.task('osm:del', () => del(osmDir));
 gulp.task(
   'osm:seed',
   gulp.series('osm:del', () =>
-    gulp.src(`${seedSourceDir}/*.pbf`).pipe(gulp.dest(osmDir)),
+    gulp
+      .src(`${seedSourceDir}/*.pbf`, { buffer: false })
+      .pipe(gulp.dest(osmDir)),
   ),
 );
 
@@ -200,7 +205,9 @@ gulp.task('dem:del', () => del(demDir));
 gulp.task(
   'dem:seed',
   gulp.series('dem:del', () =>
-    gulp.src(`${seedSourceDir}/*.tif`).pipe(gulp.dest(demDir)),
+    gulp
+      .src(`${seedSourceDir}/*.tif`, { buffer: false })
+      .pipe(gulp.dest(demDir)),
   ),
 );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,7 +146,8 @@ gulp.task(
             .pipe(gulp.dest(filterDir)),
         () => del(tmpDir),
       )
-    : () => gulp.src(`${fitDir}/*`).pipe(gulp.dest(filterDir)),
+    : () =>
+        gulp.src(`${fitDir}/*`, { buffer: false }).pipe(gulp.dest(filterDir)),
 );
 
 gulp.task('copyRules', () =>

--- a/task/ZipTask.js
+++ b/task/ZipTask.js
@@ -65,12 +65,22 @@ function extractFiles(zipName, filesToExtract, path, cb) {
         name.endsWith(`${fileName}`),
       );
       if (file) {
-        return zip
-          .file(file)
-          .async('nodebuffer')
-          .then(fileData => {
-            fs.writeFileSync(`${path}/${fileName}`, fileData);
-          });
+        return new Promise((resolve, reject) => {
+          const writeStream = fs.createWriteStream(`${path}/${fileName}`);
+          zip
+            .file(file)
+            .nodeStream()
+            .pipe(writeStream)
+            .on('error', err => {
+              process.stderr.write(
+                `Error while extracting zip file: ${err.message}\n`,
+              );
+              reject(err);
+            })
+            .on('finish', function () {
+              resolve();
+            });
+        });
       } else {
         return Promise.resolve();
       }

--- a/task/ZipTask.js
+++ b/task/ZipTask.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const { execSync } = require('child_process');
 const through = require('through2');
-const JSZip = require('jszip');
 const { parseId } = require('../util');
 const { dataDir } = require('../config.js');
 
@@ -13,40 +12,12 @@ const { dataDir } = require('../config.js');
  * @returns {Promise} A Promise that resolves when the operation is complete
  */
 function addFiles(zipFile, path, filesToAdd) {
-  return new Promise((resolve, reject) => {
-    const newZip = new JSZip();
-    fs.readFile(zipFile, function (err, data) {
-      if (err) {
-        process.stdout.write(`Error reading file ${err.message} \n`);
-        reject(err);
-      } else {
-        newZip.loadAsync(data).then(zip => {
-          filesToAdd.forEach(file => {
-            const filePath = `${path}/${file}`;
-            try {
-              const fileData = fs.readFileSync(filePath);
-              if (fileData) {
-                zip.file(`${file}`, fileData);
-              }
-            } catch {
-              process.stdout.write(`${filePath} not found\n`);
-              // nop
-            }
-          });
-          const writeStream = fs.createWriteStream(zipFile);
-          zip
-            .generateNodeStream()
-            .pipe(writeStream)
-            .on('error', err => {
-              process.stderr.write(`Error writing zip file: ${err.message}\n`);
-              reject(err);
-            })
-            .on('finish', () => {
-              resolve(zip.generateNodeStream());
-            });
-        });
-      }
-    });
+  execSync(
+    `zip -ur ${zipFile} ${filesToAdd.map(fileName => `${path}/${fileName}`).join(' ')}`,
+  );
+  process.stdout.write(`Added ${filesToAdd.join(', ')} to ${zipFile}\n`);
+  return new Promise(resolve => {
+    resolve(fs.createReadStream(zipFile));
   });
 }
 
@@ -58,35 +29,22 @@ function addFiles(zipFile, path, filesToAdd) {
  * @param {function} cb - callback to signal when finished
  */
 function extractFiles(zipName, filesToExtract, path, cb) {
-  const zip = new JSZip();
-  zip.loadAsync(fs.readFileSync(zipName)).then(() => {
-    const promises = filesToExtract.map(fileName => {
-      const file = Object.keys(zip.files).find(name =>
-        name.endsWith(`${fileName}`),
-      );
-      if (file) {
-        return new Promise((resolve, reject) => {
-          const writeStream = fs.createWriteStream(`${path}/${fileName}`);
-          zip
-            .file(file)
-            .nodeStream()
-            .pipe(writeStream)
-            .on('error', err => {
-              process.stderr.write(
-                `Error while extracting zip file: ${err.message}\n`,
-              );
-              reject(err);
-            })
-            .on('finish', function () {
-              resolve();
-            });
-        });
-      } else {
-        return Promise.resolve();
-      }
-    });
-    Promise.all(promises).then(() => cb());
-  });
+  const filesString = filesToExtract
+    .filter(name => zipHasFile(zipName, name))
+    .join(' ');
+  execSync(`unzip -o -j ${zipName} ${filesString} -d ${path}`);
+  process.stdout.write(`Extracted ${filesString} from ${zipName} to ${path}\n`);
+  cb();
+}
+
+function zipHasFile(zipName, file) {
+  try {
+    execSync(`unzip -l ${zipName} | grep -q ${file}`);
+    return true;
+    // eslint-disable-next-line no-unused-vars
+  } catch (err) {
+    return false;
+  }
 }
 
 /**

--- a/task/ZipTask.js
+++ b/task/ZipTask.js
@@ -33,13 +33,17 @@ function addFiles(zipFile, path, filesToAdd) {
               // nop
             }
           });
+          const writeStream = fs.createWriteStream(zipFile);
           zip
-            .generateAsync({ type: 'nodebuffer' })
-            .then(content => {
-              fs.writeFileSync(zipFile, content);
-              resolve(zip.generateNodeStream());
+            .generateNodeStream()
+            .pipe(writeStream)
+            .on('error', err => {
+              process.stderr.write(`Error writing zip file: ${err.message}\n`);
+              reject(err);
             })
-            .catch(err => reject(err));
+            .on('finish', () => {
+              resolve(zip.generateNodeStream());
+            });
         });
       }
     });


### PR DESCRIPTION
We ran into some memory limitations while trying to process large zip files so this changes the zip read/write to use stream instead of a buffer.