### PR TITLE
DT-6901 - Add OSM preprocessing

### DIFF
--- a/config.js
+++ b/config.js
@@ -89,7 +89,9 @@ module.exports = {
   osm: router.osm.map(id => {
     return { id, url: osm[id] };
   }), // array of id, url (OSM data) pairs
-  osmPreprocessingInstructions: router.osm.map(id => {
+  osmPreprocessingInstructions: router.osm.filter(id => {
+    return osmPreprocessingURLs[id];
+  }).map(id => {
     return { id, url: osmPreprocessingURLs[id] };
   }), // array of id, url (OSM preprocessing instruction data) pairs
   osmPreprocessingURLs,

--- a/config.js
+++ b/config.js
@@ -89,11 +89,13 @@ module.exports = {
   osm: router.osm.map(id => {
     return { id, url: osm[id] };
   }), // array of id, url (OSM data) pairs
-  osmPreprocessingInstructions: router.osm.filter(id => {
-    return osmPreprocessingURLs[id];
-  }).map(id => {
-    return { id, url: osmPreprocessingURLs[id] };
-  }), // array of id, url (OSM preprocessing instruction data) pairs
+  osmPreprocessingInstructions: router.osm
+    .filter(id => {
+      return osmPreprocessingURLs[id];
+    })
+    .map(id => {
+      return { id, url: osmPreprocessingURLs[id] };
+    }), // array of id, url (OSM preprocessing instruction data) pairs
   osmPreprocessingURLs,
   dem: router.dem ? [{ id: router.dem, url: dem[router.dem] }] : null, // currently only one DEM file is used
   dataToolImage: `hsldevcom/otp-data-tools:${process.env.TOOLS_TAG || 'v3'}`,

--- a/config.js
+++ b/config.js
@@ -69,6 +69,10 @@ const osm = {
   ...extraOSM,
 };
 
+const osmPreprocessingSteps = {
+  hsl: 'https://geocoding.blob.core.windows.net/vrk/osm-preprocessing-hsl.txt',
+};
+
 const dem = {
   waltti:
     'https://elevdata.blob.core.windows.net/elevation/waltti/waltti-10m-elevation-model_20190927.tif',
@@ -84,7 +88,10 @@ module.exports = {
   gtfsMap,
   osm: router.osm.map(id => {
     return { id, url: osm[id] };
-  }), // array of id, url pairs
+  }), // array of id, url (OSM data) pairs
+  osmPreprocessingSteps: router.osm.map(id => {
+    return { id, url: osmPreprocessingSteps[id] };
+  }), // array of id, url (OSM preprocessing instruction data) pairs
   dem: router.dem ? [{ id: router.dem, url: dem[router.dem] }] : null, // currently only one DEM file is used
   dataToolImage: `hsldevcom/otp-data-tools:${process.env.TOOLS_TAG || 'v3'}`,
   dataDir: `${process.cwd()}/data`,

--- a/config.js
+++ b/config.js
@@ -69,7 +69,7 @@ const osm = {
   ...extraOSM,
 };
 
-const osmPreprocessingSteps = {
+const osmPreprocessingURLs = {
   hsl: 'https://geocoding.blob.core.windows.net/vrk/osm-preprocessing-hsl.txt',
 };
 
@@ -89,9 +89,10 @@ module.exports = {
   osm: router.osm.map(id => {
     return { id, url: osm[id] };
   }), // array of id, url (OSM data) pairs
-  osmPreprocessingSteps: router.osm.map(id => {
-    return { id, url: osmPreprocessingSteps[id] };
+  osmPreprocessingInstructions: router.osm.map(id => {
+    return { id, url: osmPreprocessingURLs[id] };
   }), // array of id, url (OSM preprocessing instruction data) pairs
+  osmPreprocessingURLs,
   dem: router.dem ? [{ id: router.dem, url: dem[router.dem] }] : null, // currently only one DEM file is used
   dataToolImage: `hsldevcom/otp-data-tools:${process.env.TOOLS_TAG || 'v3'}`,
   dataDir: `${process.cwd()}/data`,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,6 +60,7 @@ gulp.task('osm:download', async cb => {
   createDir(osmDir);
   await dl(config.osm, osmDlDir);
   if (config.osmPreprocessingInstructions) {
+    createDir(osmPreprocessingDlDir);
     await dl(config.osmPreprocessingInstructions, osmPreprocessingDlDir);
   }
   cb();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,8 +59,8 @@ gulp.task('osm:download', async cb => {
   createDir(osmDlDir);
   createDir(osmDir);
   await dl(config.osm, osmDlDir);
-  if (config.osmPreprocessingSteps) {
-    await dl(config.osmPreprocessingSteps, osmPreprocessingDlDir);
+  if (config.osmPreprocessingInstructions) {
+    await dl(config.osmPreprocessingInstructions, osmPreprocessingDlDir);
   }
   cb();
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ const prepareFit = require('./task/PrepareFit');
 const mapFit = require('./task/MapFit');
 const { validateBlobSize } = require('./task/BlobValidation');
 const { testOTPFile } = require('./task/OTPTest');
+const { runOSMPreprocessing } = require('./task/OSMPreprocessing');
 const seed = require('./task/Seed');
 const {
   prepareRouterData,
@@ -28,6 +29,7 @@ const storageCleanup = require('./task/StorageCleanup');
 const seedSourceDir = `${config.dataDir}/router-${config.router.id}`; // e.g. data/router-hsl
 
 const osmDlDir = `${config.dataDir}/downloads/osm`;
+const osmPreprocessingDlDir = `${config.dataDir}/downloads/osm-preprocessing`;
 const demDlDir = `${config.dataDir}/downloads/dem`;
 const gtfsDlDir = `${config.dataDir}/downloads/gtfs`;
 
@@ -57,6 +59,9 @@ gulp.task('osm:download', async cb => {
   createDir(osmDlDir);
   createDir(osmDir);
   await dl(config.osm, osmDlDir);
+  if (config.osmPreprocessingSteps) {
+    await dl(config.osmPreprocessingSteps, osmPreprocessingDlDir);
+  }
   cb();
 });
 
@@ -68,6 +73,7 @@ gulp.task(
       gulp
         .src(`${osmDlDir}/*`, noBuf)
         .pipe(validateBlobSize())
+        .pipe(runOSMPreprocessing(osmPreprocessingDlDir))
         .pipe(testOTPFile())
         .pipe(gulp.dest(osmDir)),
     () => del(tmpDir),

--- a/otp-data-tools/Dockerfile
+++ b/otp-data-tools/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Digitransit (digitransit.fi)" \
       version="1.1" \
       repo="https://github.com/HSLdevcom/OpenTripPlanner-data-container"
 
-RUN apt-get update && apt-get -y install git python3 python3-pip python3-venv
+RUN apt-get update && apt-get -y install git python3 python3-pip python3-venv osmctools
 RUN rm -rf /var/lib/apt/lists/*
 RUN python3 -m venv python-venv && python-venv/bin/pip install future grequests numpy
 RUN git clone -b v3 --single-branch https://github.com/HSLdevcom/OTPQA.git

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -6,8 +6,6 @@ const exec = require('child_process').exec;
 const through = require('through2');
 const { dataDir, constants, dataToolImage, osmPreprocessingURLs } = require('../config');
 const { postSlackMessage, createDir } = require('../util');
-const Vinyl = require('vinyl');
-const cloneable = require('cloneable-readable');
 
 async function readPreprocessingInstructions(preprocessingInstructionsFile) {
   const preprocessingInstructions = [];
@@ -55,17 +53,12 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
             const concatenatedInstructions = await readPreprocessingInstructions(preprocessingInstructionsFile);
             process.stdout.write('Running command: ' + concatenatedInstructions + '\n');
             const preprocessingCommand = exec(
-              `docker run -v ${dataDir}/tmp/${dir}:/tmp/osm-preprocessing -w /tmp/osm-preprocessing --rm --entrypoint /bin/bash ${dataToolImage} ${concatenatedInstructions}`,
+              `docker run -v ${dataDir}/tmp/${dir}:/tmp/osm-preprocessing:rw -w /tmp/osm-preprocessing --rm --entrypoint /bin/bash ${dataToolImage} ${concatenatedInstructions}`,
               { maxBuffer: constants.BUFFER_SIZE },
             );
             preprocessingCommand.on('exit', function (c) {
               if (c === 0) {
-                // The temporary directory is only deleted after the whole OSM pipeline is finished,
-                // instead of directly after the preprocessing is finished.
-                resolve(new Vinyl({
-                  path: osmFileName,
-                  contents: cloneable(fs.createReadStream(`${dataDir}/tmp/${dir}/${osmFileName}`)),
-                }));
+                resolve(fs.readFileSync(`${folder}/${osmFileName}`));
                 process.stdout.write(osmFile + ' + ' + preprocessingInstructionsFile + ' OSM preprocessing SUCCESS\n');
               } else {
                 const log = lastLog.join('');
@@ -73,6 +66,7 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
                 global.hasFailures = true;
                 resolve(null);
               }
+              fse.removeSync(folder);
             });
             preprocessingCommand.stdout.on('data', function (data) {
               lastLog.push(data.toString());
@@ -123,9 +117,10 @@ module.exports = {
         return callback(null, file);
       }
       preprocessWithFile(osmFile, true, osmPreprocessingDlDir, osmId, osmFileName)
-        .then(outputFile => {
-          if (outputFile) {
-            callback(null, outputFile);
+        .then(outputContents => {
+          if (outputContents) {
+            file.contents = outputContents;
+            callback(null, file);
           } else {
             callback(null, null);
           }

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -29,19 +29,14 @@ async function readPreprocessingInstructions(preprocessingInstructionsFile) {
  * Runs the instructions listed in the OSM preprocessing file.
  * Only the osmfilter, osmconvert, and osmupdate commands can be used.
  */
-function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir) {
+function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId, osmFileName) {
   const lastLog = [];
 
   return new Promise((resolve, reject) => {
-    // This can be, for example, hsl, finland, or southFinland.
-    const osmId = osmFile.split('/').pop().split('.')[0];
     const preprocessingInstructionsFile = `${osmPreprocessingDlDir}/${osmId}.txt`;
 
     if (!fs.existsSync(osmFile)) {
       reject(new Error(`${osmFile} does not exist!\n`));
-    } else if (!osmPreprocessingURLs[osmId]) {
-      resolve(true);
-      process.stdout.write('No OSM preprocessing instructions for ' + osmId + '\n');
     } else if (!fs.existsSync(preprocessingInstructionsFile)) {
       reject(new Error(`${preprocessingInstructionsFile} does not exist!\n`));
     } else {
@@ -63,15 +58,17 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir) {
             );
             preprocessingCommand.on('exit', function (c) {
               if (c === 0) {
-                resolve(true);
+                // The temporary directory is only deleted after the whole OSM pipeline is finished,
+                // instead of directly after the preprocessing is finished.
+                const outputFile = fs.createReadStream(`${dataDir}/tmp/${dir}/${osmFileName}`);
+                resolve(outputFile);
                 process.stdout.write(osmFile + ' + ' + preprocessingInstructionsFile + ' OSM preprocessing SUCCESS\n');
               } else {
                 const log = lastLog.join('');
                 postSlackMessage(`${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom:`);
                 global.hasFailures = true;
-                resolve(false);
+                resolve(null);
               }
-              fse.removeSync(folder);
             });
             preprocessingCommand.stdout.on('data', function (data) {
               lastLog.push(data.toString());
@@ -98,7 +95,7 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir) {
             reject(e);
           }
         });
-        r.pipe(fs.createWriteStream(`${folder}/${osmFile.split('/').pop()}`));
+        r.pipe(fs.createWriteStream(`${folder}/${osmFileName}`));
       });
     }
   });
@@ -114,10 +111,17 @@ module.exports = {
         );
         return callback(null, file);
       }
-      preprocessWithFile(osmFile, true, osmPreprocessingDlDir)
-        .then(success => {
-          if (success) {
-            callback(null, file);
+      const osmFileName = osmFile.split('/').pop();
+      // This can be, for example, hsl, finland, or southFinland.
+      const osmId = osmFileName.split('.')[0];
+      if (!osmPreprocessingURLs[osmId]) {
+        process.stdout.write('No OSM preprocessing instructions for ' + osmId + '\n');
+        return callback(null, file);
+      }
+      preprocessWithFile(osmFile, true, osmPreprocessingDlDir, osmId, osmFileName)
+        .then(outputFile => {
+          if (outputFile) {
+            callback(null, outputFile);
           } else {
             callback(null, null);
           }

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -1,10 +1,29 @@
 const fs = require('fs');
+const { once } = require('events');
 const readline = require('readline');
 const fse = require('fs-extra');
 const exec = require('child_process').exec;
 const through = require('through2');
 const { dataDir, constants, dataToolImage, osmPreprocessingURLs } = require('../config');
 const { postSlackMessage, createDir } = require('../util');
+
+async function readPreprocessingInstructions(preprocessingInstructionsFile) {
+  const preprocessingInstructions = [];
+  const rl = readline.createInterface({
+    input: fs.createReadStream(preprocessingInstructionsFile),
+  });
+  rl.on('line', (line) => {
+    if (/^(osmconvert|osmfilter|osmupdate).*$/.test(line)) {
+      preprocessingInstructions.push(line);
+    } else if (line === '') {
+      process.stdout.write('Skipping empty line in ' + preprocessingInstructionsFile + '\n');
+    } else {
+      // TODO invalid command
+    }
+  });
+  await once(rl, 'close');
+  return `-c '${preprocessingInstructions.join(' && ')}'`;
+}
 
 /**
  * Runs the instructions listed in the OSM preprocessing file.
@@ -34,27 +53,10 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir) {
         );
         const dir = folder.split('/').pop();
         const r = fs.createReadStream(osmFile);
-        r.on('end', () => {
+        r.on('end', async () => {
           try {
-            let concatenatedInstructions;
-            const preprocessingInstructions = [];
-
-            const rl = readline.createInterface({
-              input: fs.createReadStream(preprocessingInstructionsFile),
-            });
-            rl.on('line', line => {
-              if (/^(osmconvert|osmfilter|osmupdate).*$/.test(line)) {
-                preprocessingInstructions.push(line);
-              } else if (line === '') {
-                process.stdout.write('Skipping empty line in ' + preprocessingInstructionsFile + '\n');
-              } else {
-                // TODO invalid command
-              }
-            });
-            rl.on('close', () => {
-              concatenatedInstructions = `sh -c '${preprocessingInstructions.join(' && ')}'`;
-            });
-
+            const concatenatedInstructions = await readPreprocessingInstructions(preprocessingInstructionsFile);
+            process.stdout.write('Running command: ' + concatenatedInstructions + '\n');
             const preprocessingCommand = exec(
               `docker run -v ${dataDir}/tmp/${dir}:/tmp/osm-preprocessing -w /tmp/osm-preprocessing --rm --entrypoint /bin/bash ${dataToolImage} ${concatenatedInstructions}`,
               { maxBuffer: constants.BUFFER_SIZE },
@@ -108,7 +110,7 @@ module.exports = {
       const osmFile = file.history[file.history.length - 1];
       if (process.env.SKIP_OSM_PREPROCESSING) {
         process.stdout.write(
-          'OSM preprocessing skipped because the SKIP_OTP_TESTS environment variable is set\n',
+          'OSM preprocessing skipped because the SKIP_OSM_PREPROCESSING environment variable is set\n',
         );
         return callback(null, file);
       }

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -4,7 +4,12 @@ const readline = require('readline');
 const fse = require('fs-extra');
 const exec = require('child_process').exec;
 const through = require('through2');
-const { dataDir, constants, dataToolImage, osmPreprocessingURLs } = require('../config');
+const {
+  dataDir,
+  constants,
+  dataToolImage,
+  osmPreprocessingURLs,
+} = require('../config');
 const { postSlackMessage, createDir } = require('../util');
 
 async function readPreprocessingInstructions(preprocessingInstructionsFile) {
@@ -13,18 +18,22 @@ async function readPreprocessingInstructions(preprocessingInstructionsFile) {
   const rl = readline.createInterface({
     input: fs.createReadStream(preprocessingInstructionsFile),
   });
-  rl.on('line', (line) => {
+  rl.on('line', line => {
     if (/^(osmconvert|osmfilter|osmupdate).*$/.test(line)) {
       preprocessingInstructions.push(line);
     } else if (line === '') {
-      process.stdout.write('Skipping empty line in ' + preprocessingInstructionsFile + '\n');
+      process.stdout.write(
+        'Skipping empty line in ' + preprocessingInstructionsFile + '\n',
+      );
     } else {
       errorLines.push(line);
     }
   });
   await once(rl, 'close');
   if (errorLines.length > 0) {
-    throw Error(`${errorLines.join(', ')} are not valid preprocessing instructions!\n`);
+    throw Error(
+      `${errorLines.join(', ')} are not valid preprocessing instructions!\n`,
+    );
   }
   return `-c '${preprocessingInstructions.join(' && ')}'`;
 }
@@ -33,7 +42,13 @@ async function readPreprocessingInstructions(preprocessingInstructionsFile) {
  * Runs the instructions listed in the OSM preprocessing file.
  * Only the osmfilter, osmconvert, and osmupdate commands can be used.
  */
-function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId, osmFileName) {
+function preprocessWithFile(
+  osmFile,
+  quiet = false,
+  osmPreprocessingDlDir,
+  osmId,
+  osmFileName,
+) {
   const lastLog = [];
 
   return new Promise((resolve, reject) => {
@@ -48,13 +63,22 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
       fs.mkdtemp(`${dataDir}/tmp/osm-preprocessing`, (err, folder) => {
         if (err) throw err;
         process.stdout.write(
-          'Running OSM preprocessing instructions from ' + osmFile + ' in directory ' + folder + '...\n',
+          'Running OSM preprocessing instructions from ' +
+            osmFile +
+            ' in directory ' +
+            folder +
+            '...\n',
         );
         const r = fs.createReadStream(osmFile);
         r.on('end', async () => {
           try {
-            const concatenatedInstructions = await readPreprocessingInstructions(preprocessingInstructionsFile);
-            process.stdout.write('Running command: ' + concatenatedInstructions + '\n');
+            const concatenatedInstructions =
+              await readPreprocessingInstructions(
+                preprocessingInstructionsFile,
+              );
+            process.stdout.write(
+              'Running command: ' + concatenatedInstructions + '\n',
+            );
             const preprocessingCommand = exec(
               `docker run -v ${folder}:/tmp/osm-preprocessing:rw -w /tmp/osm-preprocessing --rm --entrypoint /bin/bash ${dataToolImage} ${concatenatedInstructions}`,
               { maxBuffer: constants.BUFFER_SIZE },
@@ -62,10 +86,17 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
             preprocessingCommand.on('exit', function (c) {
               if (c === 0) {
                 resolve(fs.readFileSync(`${folder}/${osmFileName}`));
-                process.stdout.write(osmFile + ' + ' + preprocessingInstructionsFile + ' OSM preprocessing SUCCESS\n');
+                process.stdout.write(
+                  osmFile +
+                    ' + ' +
+                    preprocessingInstructionsFile +
+                    ' OSM preprocessing SUCCESS\n',
+                );
               } else {
                 const log = lastLog.join('');
-                postSlackMessage(`${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom:`);
+                postSlackMessage(
+                  `${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom:`,
+                );
                 global.hasFailures = true;
                 resolve(null);
               }
@@ -91,7 +122,9 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
             });
           } catch (e) {
             const log = lastLog.join('');
-            postSlackMessage(`${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom: ${e}`);
+            postSlackMessage(
+              `${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom: ${e}`,
+            );
             fse.removeSync(folder);
             reject(e);
           }
@@ -116,10 +149,18 @@ module.exports = {
       // This can be, for example, hsl, finland, or southFinland.
       const osmId = osmFileName.split('.')[0];
       if (!osmPreprocessingURLs[osmId]) {
-        process.stdout.write('No OSM preprocessing instructions for ' + osmId + '\n');
+        process.stdout.write(
+          'No OSM preprocessing instructions for ' + osmId + '\n',
+        );
         return callback(null, file);
       }
-      preprocessWithFile(osmFile, true, osmPreprocessingDlDir, osmId, osmFileName)
+      preprocessWithFile(
+        osmFile,
+        true,
+        osmPreprocessingDlDir,
+        osmId,
+        osmFileName,
+      )
         .then(outputContents => {
           if (outputContents) {
             file.contents = outputContents;

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -1,0 +1,126 @@
+const fs = require('fs');
+const readline = require('readline');
+const fse = require('fs-extra');
+const exec = require('child_process').exec;
+const through = require('through2');
+const { dataDir, constants, dataToolImage, osmPreprocessingSteps } = require('../config');
+const { postSlackMessage, createDir } = require('../util');
+
+/**
+ * Runs the instructions listed in the OSM preprocessing file.
+ * Only the osmfilter, osmconvert, and osmupdate commands can be used.
+ */
+function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir) {
+  const lastLog = [];
+
+  return new Promise((resolve, reject) => {
+    // This can be, for example, hsl, finland, or southFinland.
+    const osmId = osmFile.split('/').pop().split('.')[0];
+    const preprocessingInstructionsFile = `${osmPreprocessingDlDir}/${osmId}.txt`;
+
+    if (!fs.existsSync(osmFile)) {
+      reject(new Error(`${osmFile} does not exist!\n`));
+    } else if (!osmPreprocessingSteps[osmId]) {
+      resolve(true);
+      process.stdout.write('No OSM preprocessing instructions for ' + osmId + '\n');
+    } else if (!fs.existsSync(preprocessingInstructionsFile)) {
+      reject(new Error(`${preprocessingInstructionsFile} does not exist!\n`));
+    } else {
+      createDir(`${dataDir}/tmp`);
+      fs.mkdtemp(`${dataDir}/tmp/osm-preprocessing`, (err, folder) => {
+        if (err) throw err;
+        process.stdout.write(
+          'Running OSM preprocessing instructions from ' + osmFile + ' in directory ' + folder + '...\n',
+        );
+        const dir = folder.split('/').pop();
+        const r = fs.createReadStream(osmFile);
+        r.on('end', () => {
+          try {
+            let concatenatedInstructions;
+            const preprocessingInstructions = [];
+
+            const rl = readline.createInterface({
+              input: fs.createReadStream(preprocessingInstructionsFile),
+            });
+            rl.on('line', line => {
+              if (/^(osmconvert|osmfilter|osmupdate).*$/.test(line)) {
+                preprocessingInstructions.push(line);
+              } else {
+                // TODO invalid command
+              }
+            });
+            rl.on('close', () => {
+              concatenatedInstructions = `sh -c '${preprocessingInstructions.join(' && ')}'`;
+            });
+
+            const preprocessingCommand = exec(
+              `docker run -v ${dataDir}/tmp/${dir}:/tmp/osm-preprocessing -w /tmp/osm-preprocessing --rm --entrypoint /bin/bash ${dataToolImage} ${concatenatedInstructions}`,
+              { maxBuffer: constants.BUFFER_SIZE },
+            );
+            preprocessingCommand.on('exit', function (c) {
+              if (c === 0) {
+                resolve(true);
+                process.stdout.write(osmFile + ' + ' + preprocessingInstructionsFile + ' OSM preprocessing SUCCESS\n');
+              } else {
+                const log = lastLog.join('');
+                postSlackMessage(`${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom:`);
+                global.hasFailures = true;
+                resolve(false);
+              }
+              fse.removeSync(folder);
+            });
+            preprocessingCommand.stdout.on('data', function (data) {
+              lastLog.push(data.toString());
+              if (lastLog.length === 20) {
+                delete lastLog[0];
+              }
+              if (!quiet) {
+                process.stdout.write(data.toString());
+              }
+            });
+            preprocessingCommand.stderr.on('data', function (data) {
+              lastLog.push(data.toString());
+              if (lastLog.length > 20) {
+                lastLog.splice(0, 1);
+              }
+              if (!quiet) {
+                process.stderr.write(data.toString());
+              }
+            });
+          } catch (e) {
+            const log = lastLog.join('');
+            postSlackMessage(`${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom:`);
+            fse.removeSync(folder);
+            reject(e);
+          }
+        });
+        r.pipe(fs.createWriteStream(`${folder}/${osmFile.split('/').pop()}`));
+      });
+    }
+  });
+}
+
+module.exports = {
+  runOSMPreprocessing: osmPreprocessingDlDir => {
+    return through.obj(function (file, encoding, callback) {
+      const osmFile = file.history[file.history.length - 1];
+      if (process.env.SKIP_OSM_PREPROCESSING) {
+        process.stdout.write(
+          'OSM preprocessing skipped because the SKIP_OTP_TESTS environment variable is set\n',
+        );
+        return callback(null, file);
+      }
+      preprocessWithFile(osmFile, true, osmPreprocessingDlDir)
+        .then(success => {
+          if (success) {
+            callback(null, file);
+          } else {
+            callback(null, null);
+          }
+        })
+        .catch(() => {
+          callback(null, null);
+        });
+    });
+  },
+};

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -3,7 +3,7 @@ const readline = require('readline');
 const fse = require('fs-extra');
 const exec = require('child_process').exec;
 const through = require('through2');
-const { dataDir, constants, dataToolImage, osmPreprocessingSteps } = require('../config');
+const { dataDir, constants, dataToolImage, osmPreprocessingURLs } = require('../config');
 const { postSlackMessage, createDir } = require('../util');
 
 /**
@@ -20,7 +20,7 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir) {
 
     if (!fs.existsSync(osmFile)) {
       reject(new Error(`${osmFile} does not exist!\n`));
-    } else if (!osmPreprocessingSteps[osmId]) {
+    } else if (!osmPreprocessingURLs[osmId]) {
       resolve(true);
       process.stdout.write('No OSM preprocessing instructions for ' + osmId + '\n');
     } else if (!fs.existsSync(preprocessingInstructionsFile)) {
@@ -45,6 +45,8 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir) {
             rl.on('line', line => {
               if (/^(osmconvert|osmfilter|osmupdate).*$/.test(line)) {
                 preprocessingInstructions.push(line);
+              } else if (line === '') {
+                process.stdout.write('Skipping empty line in ' + preprocessingInstructionsFile + '\n');
               } else {
                 // TODO invalid command
               }

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -6,6 +6,8 @@ const exec = require('child_process').exec;
 const through = require('through2');
 const { dataDir, constants, dataToolImage, osmPreprocessingURLs } = require('../config');
 const { postSlackMessage, createDir } = require('../util');
+const Vinyl = require('vinyl');
+const cloneable = require('cloneable-readable');
 
 async function readPreprocessingInstructions(preprocessingInstructionsFile) {
   const preprocessingInstructions = [];
@@ -18,7 +20,7 @@ async function readPreprocessingInstructions(preprocessingInstructionsFile) {
     } else if (line === '') {
       process.stdout.write('Skipping empty line in ' + preprocessingInstructionsFile + '\n');
     } else {
-      throw Error(`'${line}' is not a valid preprocessing instruction!\n`)
+      throw Error(`'${line}' is not a valid preprocessing instruction!\n`);
     }
   });
   await once(rl, 'close');
@@ -60,8 +62,10 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
               if (c === 0) {
                 // The temporary directory is only deleted after the whole OSM pipeline is finished,
                 // instead of directly after the preprocessing is finished.
-                const outputFile = fs.createReadStream(`${dataDir}/tmp/${dir}/${osmFileName}`);
-                resolve(outputFile);
+                resolve(new Vinyl({
+                  path: osmFileName,
+                  contents: cloneable(fs.createReadStream(`${dataDir}/tmp/${dir}/${osmFileName}`)),
+                }));
                 process.stdout.write(osmFile + ' + ' + preprocessingInstructionsFile + ' OSM preprocessing SUCCESS\n');
               } else {
                 const log = lastLog.join('');

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -9,6 +9,7 @@ const { postSlackMessage, createDir } = require('../util');
 
 async function readPreprocessingInstructions(preprocessingInstructionsFile) {
   const preprocessingInstructions = [];
+  const errorLines = [];
   const rl = readline.createInterface({
     input: fs.createReadStream(preprocessingInstructionsFile),
   });
@@ -18,10 +19,13 @@ async function readPreprocessingInstructions(preprocessingInstructionsFile) {
     } else if (line === '') {
       process.stdout.write('Skipping empty line in ' + preprocessingInstructionsFile + '\n');
     } else {
-      throw Error(`'${line}' is not a valid preprocessing instruction!\n`);
+      errorLines.push(line);
     }
   });
   await once(rl, 'close');
+  if (errorLines.length > 0) {
+    throw Error(`${errorLines.join(', ')} are not valid preprocessing instructions!\n`);
+  }
   return `-c '${preprocessingInstructions.join(' && ')}'`;
 }
 
@@ -87,7 +91,7 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
             });
           } catch (e) {
             const log = lastLog.join('');
-            postSlackMessage(`${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom:`);
+            postSlackMessage(`${osmFile} + ${preprocessingInstructionsFile} OSM preprocessing failed: ${log} :boom: ${e}`);
             fse.removeSync(folder);
             reject(e);
           }

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -18,7 +18,7 @@ async function readPreprocessingInstructions(preprocessingInstructionsFile) {
     } else if (line === '') {
       process.stdout.write('Skipping empty line in ' + preprocessingInstructionsFile + '\n');
     } else {
-      // TODO invalid command
+      throw Error(`'${line}' is not a valid preprocessing instruction!\n`)
     }
   });
   await once(rl, 'close');

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -64,6 +64,8 @@ function preprocessWithFile(
         if (err) throw err;
         process.stdout.write(
           'Running OSM preprocessing instructions from ' +
+            preprocessingInstructionsFile +
+            ' for ' +
             osmFile +
             ' in directory ' +
             folder +

--- a/task/OSMPreprocessing.js
+++ b/task/OSMPreprocessing.js
@@ -46,14 +46,13 @@ function preprocessWithFile(osmFile, quiet = false, osmPreprocessingDlDir, osmId
         process.stdout.write(
           'Running OSM preprocessing instructions from ' + osmFile + ' in directory ' + folder + '...\n',
         );
-        const dir = folder.split('/').pop();
         const r = fs.createReadStream(osmFile);
         r.on('end', async () => {
           try {
             const concatenatedInstructions = await readPreprocessingInstructions(preprocessingInstructionsFile);
             process.stdout.write('Running command: ' + concatenatedInstructions + '\n');
             const preprocessingCommand = exec(
-              `docker run -v ${dataDir}/tmp/${dir}:/tmp/osm-preprocessing:rw -w /tmp/osm-preprocessing --rm --entrypoint /bin/bash ${dataToolImage} ${concatenatedInstructions}`,
+              `docker run -v ${folder}:/tmp/osm-preprocessing:rw -w /tmp/osm-preprocessing --rm --entrypoint /bin/bash ${dataToolImage} ${concatenatedInstructions}`,
               { maxBuffer: constants.BUFFER_SIZE },
             );
             preprocessingCommand.on('exit', function (c) {


### PR DESCRIPTION
- The preprocessing works based on a file in blob storage
  - The file can only contain `osmconvert`, `osmfilter`, or `osmupdate` instructions
- No configured preprocessing steps for a specific OSM file means that no preprocessing is done for the file
- Having the `SKIP_OSM_PREPROCESSING` option set means that the preprocessing is not run at all