### PR TITLE
Option to freeze OSM data to the previous version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It is possible to change the behaviour of the data builder by defining environme
   - `ONLY_BUILD_STREET_GRAPH` to only build the street graph
   - `USE_PREBUILT_STREET_GRAPH` to use the prebuilt street graph to finish a complete graph build
   - All other values default to `NO_SPLIT_BUILD` which indicates that the build is run as normal
-- (Optional) `FREEZE_OSM` skips OSM updating and uses existing seed version
+- (Optional) `USE_SEEDED_OSM` skips OSM updating and uses existing seed version
 
 ### Data processing steps
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ It is possible to change the behaviour of the data builder by defining environme
   - `ONLY_BUILD_STREET_GRAPH` to only build the street graph
   - `USE_PREBUILT_STREET_GRAPH` to use the prebuilt street graph to finish a complete graph build
   - All other values default to `NO_SPLIT_BUILD` which indicates that the build is run as normal
+- (Optional) `FREEZE_OSM` skips OSM updating and uses existing seed version
 
 ### Data processing steps
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -47,20 +47,24 @@ async function handleOsmAndDemUpdate() {
 
   // OSM update is more complicated. Download often fails, so there is a retry loop,
   // which breaks when a big enough file gets loaded
-  global.blobSizeOk = false; // ugly hack but gulp does not return any values from tasks
-  for (let i = 0; i < 3; i++) {
-    await start('osm:update');
-    if (global.blobSizeOk) {
-      break;
+  if (!process.env.FREEZE_OSM) {
+    global.blobSizeOk = false; // ugly hack but gulp does not return any values from tasks
+    for (let i = 0; i < 3; i++) {
+      await start('osm:update');
+      if (global.blobSizeOk) {
+	break;
+      }
+      if (i < 2) {
+	// sleep 10 mins before next attempt
+	await new Promise(resolve => setTimeout(resolve, 600000));
+      }
     }
-    if (i < 2) {
-      // sleep 10 mins before next attempt
-      await new Promise(resolve => setTimeout(resolve, 600000));
+    if (!global.blobSizeOk) {
+      global.hasFailures = true;
+      postSlackMessage('OSM data update failed, using previous version :boom:');
     }
-  }
-  if (!global.blobSizeOk) {
-    global.hasFailures = true;
-    postSlackMessage('OSM data update failed, using previous version :boom:');
+  } else {
+    process.stdout.write('Skipping OSM update and using previuous version\n');
   }
 }
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -52,11 +52,11 @@ async function handleOsmAndDemUpdate() {
     for (let i = 0; i < 3; i++) {
       await start('osm:update');
       if (global.blobSizeOk) {
-	break;
+        break;
       }
       if (i < 2) {
-	// sleep 10 mins before next attempt
-	await new Promise(resolve => setTimeout(resolve, 600000));
+        // sleep 10 mins before next attempt
+        await new Promise(resolve => setTimeout(resolve, 600000));
       }
     }
     if (!global.blobSizeOk) {

--- a/task/Update.js
+++ b/task/Update.js
@@ -64,7 +64,9 @@ async function handleOsmAndDemUpdate() {
       postSlackMessage('OSM data update failed, using previous version :boom:');
     }
   } else {
-    process.stdout.write('Skipping OSM update and using existing seeded data\n');
+    process.stdout.write(
+      'Skipping OSM update and using existing seeded data\n',
+    );
   }
 }
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -64,7 +64,7 @@ async function handleOsmAndDemUpdate() {
       postSlackMessage('OSM data update failed, using previous version :boom:');
     }
   } else {
-    process.stdout.write('Skipping OSM update and using previuous version\n');
+    process.stdout.write('Skipping OSM update and using existing seeded data\n');
   }
 }
 

--- a/task/Update.js
+++ b/task/Update.js
@@ -47,7 +47,7 @@ async function handleOsmAndDemUpdate() {
 
   // OSM update is more complicated. Download often fails, so there is a retry loop,
   // which breaks when a big enough file gets loaded
-  if (!process.env.FREEZE_OSM) {
+  if (!process.env.USE_SEEDED_OSM) {
     global.blobSizeOk = false; // ugly hack but gulp does not return any values from tasks
     for (let i = 0; i < 3; i++) {
       await start('osm:update');


### PR DESCRIPTION
We occasionally find out that a problematic change is made to OSM data and need some time to mitigate it. An easy switch to prevent OSM updates will be convenient.  