### PR TITLE
DT-6967 unprefer some lappeenranta routes

### DIFF
--- a/waltti/router-config.json
+++ b/waltti/router-config.json
@@ -49,6 +49,14 @@
         "costLimitFunction": "600 + 1.5x"
       },
       "nonTransitGeneralizedCostLimit": "400 + 1.5x"
+    },
+    "unpreferredCost": "1 + 0.4x",
+    "unpreferred": {
+      "routes": [
+        "Lappeenranta:100",
+        "Lappeenranta:101",
+        "Lappeenranta:110"
+      ]
     }
   },
   "gtfsApi": {

--- a/waltti/router-config.json
+++ b/waltti/router-config.json
@@ -52,11 +52,7 @@
     },
     "unpreferredCost": "1 + 0.4x",
     "unpreferred": {
-      "routes": [
-        "Lappeenranta:100",
-        "Lappeenranta:101",
-        "Lappeenranta:110"
-      ]
+      "routes": ["Lappeenranta:100", "Lappeenranta:101", "Lappeenranta:110"]
     }
   },
   "gtfsApi": {


### PR DESCRIPTION
Search below not returns itineraries using routes 111, 112 and 113.

https://lappeenranta.digitransit.fi/reitti/Joutsenon%20keskus%2C%20Lappeenranta%3A%3A61.118177%2C28.501515/Armada%2C%20Kauppakatu%2029-31%2C%20Lappeenranta%3A%3A61.059221%2C28.185381?setTime=true&time=1758168000
