### PR TITLE
Adjust car transit values in kela config

### DIFF
--- a/kela/build-config.json
+++ b/kela/build-config.json
@@ -21,7 +21,7 @@
   "transferParametersForMode": {
     "CAR": {
       "disableDefaultTransfers": true,
-      "carsAllowedStopMaxTransferDuration": "2h"
+      "carsAllowedStopMaxTransferDuration": "90m"
     }
   },
   "boardingLocationTags": ["ref", "ref:findt", "ref:findr"],

--- a/kela/router-config.json
+++ b/kela/router-config.json
@@ -10,7 +10,8 @@
       "reluctance": 1.7
     },
     "car": {
-      "reluctance": 10.0
+      "reluctance": 10.0,
+      "boardCost": 600
     },
     "walk": {
       "speed": 1.3,
@@ -26,7 +27,7 @@
       "maxDuration": "8h",
       "maxStopCount": "400",
       "maxDurationForMode": {
-        "CAR": "3h"
+        "CAR": "90m"
       },
       "maxStopCountForMode": {
         "CAR": 0


### PR DESCRIPTION
This improves routing speed by lowering access egress and transfer durations. It also adds the missing car `boardCost` for kela.