### PR TITLE
AB#238 - Adjust flex and car transit values to make routing more performant

### DIFF
--- a/finland/build-config.json
+++ b/finland/build-config.json
@@ -25,11 +25,11 @@
   "transferParametersForMode": {
     "CAR": {
       "disableDefaultTransfers": true,
-      "carsAllowedStopMaxTransferDuration": "2h"
+      "carsAllowedStopMaxTransferDuration": "90m"
     },
     "BIKE": {
       "maxTransferDuration": "30m",
-      "carsAllowedStopMaxTransferDuration": "2h"
+      "carsAllowedStopMaxTransferDuration": "90m"
     }
   },
   "boardingLocationTags": ["ref", "ref:findt", "ref:findr"],

--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -30,7 +30,7 @@
       "maxDurationForMode": {
         "CAR_TO_PARK": "2h",
         "BIKE": "2h",
-        "CAR": "3h"
+        "CAR": "90m"
       },
       "maxStopCountForMode": {
         "BIKE": 0,
@@ -69,9 +69,10 @@
   },
   "flex": {
     "maxTransferDuration": "1m",
-    "maxFlexTripDuration": "3h",
+    "maxFlexTripDuration": "1h",
     "maxAccessWalkDuration": "5m",
-    "maxEgressWalkDuration": "5m"
+    "maxEgressWalkDuration": "5m",
+    "maxFlexStopCount": 300
   },
   "transit": {
     "pagingSearchWindowAdjustments": ["8h", "4h", "4h", "4h", "4h"],


### PR DESCRIPTION
- `maxFlexStopCount` requires custom changes that were added to our current dev branch