### PR TITLE
Use smoove id for Helsinki/Espoo rental again

### DIFF
--- a/finland/router-config.json
+++ b/finland/router-config.json
@@ -598,7 +598,7 @@
       "id": "hsl-bike-rental",
       "type": "vehicle-rental",
       "sourceType": "gbfs",
-      "network": "hsl",
+      "network": "smoove",
       "frequency": "30s",
       "url": "http://digitransit-proxy:8080/out/gbfs.theta.fifteen.eu/gbfs/2.2/helsinki/en/gbfs.json",
       "overloadingAllowed": true,

--- a/hsl/router-config.json
+++ b/hsl/router-config.json
@@ -261,7 +261,7 @@
       "id": "hsl-bike-rental",
       "type": "vehicle-rental",
       "sourceType": "gbfs",
-      "network": "hsl",
+      "network": "smoove",
       "frequency": "30s",
       "url": "http://digitransit-proxy:8080/out/gbfs.theta.fifteen.eu/gbfs/2.2/helsinki/en/gbfs.json",
       "overloadingAllowed": true,


### PR DESCRIPTION
The Helsinki/Espoo network was called smoove last season and we tried to change it to hsl, but there wasn't enough time to update all integrations to use the new id so we are reverting the id change.